### PR TITLE
feat(config): add server grouping feature

### DIFF
--- a/internal/adapters/data/file/writer.go
+++ b/internal/adapters/data/file/writer.go
@@ -24,11 +24,22 @@ import (
 
 type SSHConfigWriter struct{}
 
-func (w *SSHConfigWriter) Write(writer io.Writer, servers []domain.Server) error {
+func (w *SSHConfigWriter) Write(writer io.Writer, servers []domain.Server, directives []string) error {
 	bufWriter := bufio.NewWriter(writer)
 	defer func() {
 		_ = bufWriter.Flush()
 	}()
+
+	if len(directives) > 0 {
+		for _, directive := range directives {
+			if _, err := fmt.Fprintln(bufWriter, directive); err != nil {
+				return err
+			}
+		}
+		if _, err := bufWriter.WriteString("\n"); err != nil {
+			return err
+		}
+	}
 
 	if _, err := fmt.Fprintf(bufWriter, "%s\n\n", ManagedByComment); err != nil {
 		return err

--- a/internal/adapters/ui/server_details.go
+++ b/internal/adapters/ui/server_details.go
@@ -69,11 +69,15 @@ func (sd *ServerDetails) UpdateServer(server domain.Server) {
 	if server.PinnedAt.IsZero() {
 		pinnedStr = "false"
 	}
+	groupText := server.Group
+	if groupText == "" {
+		groupText = "-"
+	}
 	tagsText := renderTagChips(server.Tags)
 	text := fmt.Sprintf(
-		"[::b]%s[-]\n\nHost: [white]%s[-]\nUser: [white]%s[-]\nPort: [white]%d[-]\nKey:  [white]%s[-]\nTags: %s\nPinned: [white]%s[-]\nLast SSH: %s\nSSH Count: [white]%d[-]\n\n[::b]Commands:[-]\n  Enter: SSH connect\n  c: Copy SSH command\n  g: Ping server\n  r: Refresh list\n  a: Add new server\n  e: Edit entry\n  t: Edit tags\n  d: Delete entry\n  p: Pin/Unpin",
+		"[::b]%s[-]\n\nHost: [white]%s[-]\nUser: [white]%s[-]\nPort: [white]%d[-]\nKey:  [white]%s[-]\nTags: %s\nGroup: [white]%s[-]\nPinned: [white]%s[-]\nLast SSH: %s\nSSH Count: [white]%d[-]\n\n[::b]Commands:[-]\n  Enter: SSH connect\n  c: Copy SSH command\n  g: Ping server\n  r: Refresh list\n  a: Add new server\n  e: Edit entry\n  t: Edit tags\n  d: Delete entry\n  p: Pin/Unpin",
 		server.Alias, server.Host, server.User, server.Port,
-		serverKey, tagsText, pinnedStr,
+		serverKey, tagsText, groupText, pinnedStr,
 		lastSeen, server.SSHCount)
 	sd.TextView.SetText(text)
 }

--- a/internal/adapters/ui/server_form.go
+++ b/internal/adapters/ui/server_form.go
@@ -84,6 +84,7 @@ func (sf *ServerForm) addFormFields() {
 			Port:  fmt.Sprint(sf.original.Port),
 			Key:   sf.original.Key,
 			Tags:  strings.Join(sf.original.Tags, ", "),
+			Group: sf.original.Group,
 		}
 	} else {
 		defaultValues = ServerFormData{
@@ -99,6 +100,7 @@ func (sf *ServerForm) addFormFields() {
 	sf.Form.AddInputField("Port:", defaultValues.Port, 20, nil, nil)
 	sf.Form.AddInputField("Key:", defaultValues.Key, 40, nil, nil)
 	sf.Form.AddInputField("Tags (comma):", defaultValues.Tags, 30, nil, nil)
+	sf.Form.AddInputField("Group:", defaultValues.Group, 30, nil, nil)
 }
 
 type ServerFormData struct {
@@ -108,6 +110,7 @@ type ServerFormData struct {
 	Port  string
 	Key   string
 	Tags  string
+	Group string
 }
 
 func (sf *ServerForm) getFormData() ServerFormData {
@@ -118,6 +121,7 @@ func (sf *ServerForm) getFormData() ServerFormData {
 		Port:  strings.TrimSpace(sf.Form.GetFormItem(3).(*tview.InputField).GetText()),
 		Key:   strings.TrimSpace(sf.Form.GetFormItem(4).(*tview.InputField).GetText()),
 		Tags:  strings.TrimSpace(sf.Form.GetFormItem(5).(*tview.InputField).GetText()),
+		Group: strings.TrimSpace(sf.Form.GetFormItem(6).(*tview.InputField).GetText()),
 	}
 }
 
@@ -170,6 +174,7 @@ func (sf *ServerForm) dataToServer(data ServerFormData) domain.Server {
 		Port:  port,
 		Key:   data.Key,
 		Tags:  tags,
+		Group: data.Group,
 	}
 }
 

--- a/internal/core/domain/server.go
+++ b/internal/core/domain/server.go
@@ -23,6 +23,7 @@ type Server struct {
 	Port     int
 	Key      string
 	Tags     []string
+	Group    string
 	LastSeen time.Time
 	PinnedAt time.Time
 	SSHCount int


### PR DESCRIPTION
This PR introduces a server grouping feature to lazyssh, allowing users to organize their SSH configurations into separate files for better management and clarity.

### Description

Users can now assign a "Group" to a server through the UI. Each group is stored as a separate file within the `~/.ssh/config.d/` directory. The main `~/.ssh/config` file will use an `Include config.d/*` directive to load all server configurations from these group files.

### Key Changes

- **Server Grouping:** A `Group` field has been added to the server model and integrated into the "Add/Edit" form and the server details view.
- **Non-Destructive Parsing:** The SSH config parser has been completely rewritten. It now recursively parses all files specified by `Include` directives.
- **Configuration Preservation:** The file writing logic is now much more robust. It identifies and preserves any custom `Include` directives a user might have in *any* of their SSH config files, ensuring that user configurations are not overwritten.
- **Automatic Cleanup:** When the last server in a group is deleted, the corresponding group file in `~/.ssh/config.d/` is now automatically removed.

### How to Test

1.  Run the application.
2.  Add a new server and assign it to a group (e.g., "work").
3.  Verify that the server entry is created in a new file at `~/.ssh/config.d/work`.
4.  Verify that the main `~/.ssh/config` file now contains `Include config.d/*`.
5.  Edit a server to change its group. Verify it moves to the correct file.
6.  Delete the server from the "work" group.
7.  Verify that the `~/.ssh/config.d/work` file is automatically deleted.

feat: #8