### PR TITLE
feat: Implement Ping All feature with right-aligned status indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ make run
 | Enter | SSH into selected server      |
 | c     | Copy SSH command to clipboard |
 | g     | Ping selected server          |
+| G     | Ping all servers              |
 | r     | Refresh background data       |
 | a     | Add server                    |
 | e     | Edit server                   |

--- a/internal/adapters/ui/hint_bar.go
+++ b/internal/adapters/ui/hint_bar.go
@@ -22,6 +22,6 @@ import (
 func NewHintBar() *tview.TextView {
 	hint := tview.NewTextView().SetDynamicColors(true)
 	hint.SetBackgroundColor(tcell.Color233)
-	hint.SetText("[#BBBBBB]Press [::b]/[-:-:b] to search…  •  ↑↓ Navigate  •  Enter SSH  •  c Copy SSH  •  g Ping  •  r Refresh  •  a Add  •  e Edit  •  t Tags  •  d Delete  •  p Pin/Unpin  •  s Sort[-]")
+	hint.SetText("[#BBBBBB]Press [::b]/[-:-:b] to search…  •  ↑↓ Navigate  •  Enter SSH  •  c Copy SSH  •  g/G Ping (All)  •  r Refresh  •  a Add  •  e Edit  •  t Tags  •  d Delete  •  p Pin/Unpin  •  s Sort[-]")
 	return hint
 }

--- a/internal/adapters/ui/server_form_test.go
+++ b/internal/adapters/ui/server_form_test.go
@@ -1,0 +1,133 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Adembc/lazyssh/internal/core/domain"
+)
+
+func TestServersDifferIgnoresTransientFields(t *testing.T) {
+	sf := &ServerForm{}
+
+	// Create two servers with identical config but different transient fields
+	server1 := domain.Server{
+		Alias:       "test-server",
+		Host:        "example.com",
+		User:        "testuser",
+		Port:        22,
+		PingStatus:  "up",
+		PingLatency: 100 * time.Millisecond,
+		LastSeen:    time.Now(),
+		PinnedAt:    time.Now(),
+		SSHCount:    5,
+	}
+
+	server2 := domain.Server{
+		Alias:       "test-server",
+		Host:        "example.com",
+		User:        "testuser",
+		Port:        22,
+		PingStatus:  "down",                        // Different transient field
+		PingLatency: 200 * time.Millisecond,        // Different transient field
+		LastSeen:    time.Now().Add(1 * time.Hour), // Different metadata field
+		PinnedAt:    time.Now().Add(2 * time.Hour), // Different metadata field
+		SSHCount:    10,                            // Different metadata field
+	}
+
+	// Should not detect differences since only transient/metadata fields differ
+	if sf.serversDiffer(server1, server2) {
+		t.Error("serversDiffer should ignore transient and metadata fields")
+	}
+
+	// Now change a real config field
+	server2.Port = 2222
+
+	// Should detect the difference now
+	if !sf.serversDiffer(server1, server2) {
+		t.Error("serversDiffer should detect differences in non-transient fields")
+	}
+}
+
+func TestServersDifferDetectsRealChanges(t *testing.T) {
+	sf := &ServerForm{}
+
+	server1 := domain.Server{
+		Alias: "test-server",
+		Host:  "example.com",
+		User:  "testuser",
+		Port:  22,
+	}
+
+	testCases := []struct {
+		name   string
+		modify func(*domain.Server)
+		expect bool
+	}{
+		{
+			name:   "No changes",
+			modify: func(s *domain.Server) {},
+			expect: false,
+		},
+		{
+			name:   "Changed Host",
+			modify: func(s *domain.Server) { s.Host = "different.com" },
+			expect: true,
+		},
+		{
+			name:   "Changed User",
+			modify: func(s *domain.Server) { s.User = "otheruser" },
+			expect: true,
+		},
+		{
+			name:   "Changed Port",
+			modify: func(s *domain.Server) { s.Port = 2222 },
+			expect: true,
+		},
+		{
+			name:   "Added IdentityFile",
+			modify: func(s *domain.Server) { s.IdentityFiles = []string{"~/.ssh/id_rsa"} },
+			expect: true,
+		},
+		{
+			name:   "Changed ProxyJump",
+			modify: func(s *domain.Server) { s.ProxyJump = "jumphost" },
+			expect: true,
+		},
+		{
+			name:   "Changed only PingStatus (transient)",
+			modify: func(s *domain.Server) { s.PingStatus = "checking" },
+			expect: false,
+		},
+		{
+			name:   "Changed only LastSeen (metadata)",
+			modify: func(s *domain.Server) { s.LastSeen = time.Now().Add(1 * time.Hour) },
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server2 := server1 // Copy
+			tc.modify(&server2)
+			result := sf.serversDiffer(server1, server2)
+			if result != tc.expect {
+				t.Errorf("Expected %v but got %v for test case %s", tc.expect, result, tc.name)
+			}
+		})
+	}
+}

--- a/internal/adapters/ui/server_list.go
+++ b/internal/adapters/ui/server_list.go
@@ -56,6 +56,13 @@ func (sl *ServerList) build() {
 }
 
 func (sl *ServerList) UpdateServers(servers []domain.Server) {
+	// Save current selection before clearing
+	currentIdx := sl.List.GetCurrentItem()
+	var currentAlias string
+	if currentIdx >= 0 && currentIdx < len(sl.servers) {
+		currentAlias = sl.servers[currentIdx].Alias
+	}
+
 	sl.servers = servers
 	sl.List.Clear()
 
@@ -63,6 +70,7 @@ func (sl *ServerList) UpdateServers(servers []domain.Server) {
 	_, _, width, _ := sl.List.GetInnerRect() //nolint:dogsled
 	sl.currentWidth = width
 
+	newSelectedIdx := -1
 	for i := range servers {
 		primary, secondary := formatServerLine(servers[i], width)
 		idx := i
@@ -71,12 +79,24 @@ func (sl *ServerList) UpdateServers(servers []domain.Server) {
 				sl.onSelection(sl.servers[idx])
 			}
 		})
+		// Track the new index of previously selected server
+		if currentAlias != "" && servers[i].Alias == currentAlias {
+			newSelectedIdx = i
+		}
 	}
 
 	if sl.List.GetItemCount() > 0 {
-		sl.List.SetCurrentItem(0)
-		if sl.onSelectionChange != nil {
-			sl.onSelectionChange(sl.servers[0])
+		// Restore previous selection if found, otherwise keep first item
+		if newSelectedIdx >= 0 {
+			sl.List.SetCurrentItem(newSelectedIdx)
+			if sl.onSelectionChange != nil {
+				sl.onSelectionChange(sl.servers[newSelectedIdx])
+			}
+		} else {
+			sl.List.SetCurrentItem(0)
+			if sl.onSelectionChange != nil {
+				sl.onSelectionChange(sl.servers[0])
+			}
 		}
 	}
 }

--- a/internal/adapters/ui/status_bar.go
+++ b/internal/adapters/ui/status_bar.go
@@ -20,7 +20,7 @@ import (
 )
 
 func DefaultStatusText() string {
-	return "[white]↑↓[-] Navigate  • [white]Enter[-] SSH  • [white]c[-] Copy SSH  • [white]a[-] Add  • [white]e[-] Edit  • [white]g[-] Ping  • [white]d[-] Delete  • [white]p[-] Pin/Unpin  • [white]/[-] Search  • [white]q[-] Quit"
+	return "[white]↑↓[-] Navigate  • [white]Enter[-] SSH  • [white]c[-] Copy SSH  • [white]a[-] Add  • [white]e[-] Edit  • [white]g/G[-] Ping (All)  • [white]d[-] Delete  • [white]p[-] Pin/Unpin  • [white]/[-] Search  • [white]q[-] Quit"
 }
 
 func NewStatusBar() *tview.TextView {

--- a/internal/adapters/ui/tui.go
+++ b/internal/adapters/ui/tui.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"go.uber.org/zap"
 
+	"github.com/Adembc/lazyssh/internal/core/domain"
 	"github.com/Adembc/lazyssh/internal/core/ports"
 	"github.com/rivo/tview"
 )
@@ -48,6 +49,8 @@ type tui struct {
 
 	sortMode      SortMode
 	searchVisible bool
+
+	pingStatuses map[string]domain.Server // stores ping status for each server
 }
 
 func NewTUI(logger *zap.SugaredLogger, ss ports.ServerService, version, commit string) App {
@@ -57,6 +60,7 @@ func NewTUI(logger *zap.SugaredLogger, ss ports.ServerService, version, commit s
 		serverService: ss,
 		version:       version,
 		commit:        commit,
+		pingStatuses:  make(map[string]domain.Server),
 	}
 }
 
@@ -127,6 +131,14 @@ func (t *tui) buildLayout() *tui {
 
 func (t *tui) bindEvents() *tui {
 	t.root.SetInputCapture(t.handleGlobalKeys)
+
+	// Handle window resize
+	t.app.SetBeforeDrawFunc(func(screen tcell.Screen) bool {
+		// Refresh server list display on resize
+		t.serverList.RefreshDisplay()
+		return false
+	})
+
 	return t
 }
 

--- a/internal/adapters/ui/utils.go
+++ b/internal/adapters/ui/utils.go
@@ -89,7 +89,7 @@ func formatServerLine(s domain.Server, width int) (primary, secondary string) {
 	pingIndicator := ""
 	if s.PingStatus != "" {
 		switch s.PingStatus {
-		case "up":
+		case statusUp:
 			if s.PingLatency > 0 {
 				ms := s.PingLatency.Milliseconds()
 				var statusText string
@@ -106,9 +106,9 @@ func formatServerLine(s domain.Server, width int) (primary, secondary string) {
 			} else {
 				pingIndicator = "[#4AF626]● UP  [-]"
 			}
-		case "down":
+		case statusDown:
 			pingIndicator = "[#FF6B6B]● DOWN[-]"
-		case "checking":
+		case statusChecking:
 			pingIndicator = "[#FFB86C]● ... [-]"
 		}
 	}
@@ -133,11 +133,11 @@ func formatServerLine(s domain.Server, width int) (primary, secondary string) {
 			// Medium screen: show only dot
 			simplePingIndicator := ""
 			switch s.PingStatus {
-			case "up":
+			case statusUp:
 				simplePingIndicator = "[#4AF626]●[-]"
-			case "down":
+			case statusDown:
 				simplePingIndicator = "[#FF6B6B]●[-]"
-			case "checking":
+			case statusChecking:
 				simplePingIndicator = "[#FFB86C]●[-]"
 			}
 			paddingLen := width - mainTextLen - 1 // 1 for dot, no margin

--- a/internal/core/domain/server.go
+++ b/internal/core/domain/server.go
@@ -27,6 +27,8 @@ type Server struct {
 	LastSeen      time.Time
 	PinnedAt      time.Time
 	SSHCount      int
+	PingStatus    string        // "up", "down", "checking", or ""
+	PingLatency   time.Duration // ping latency
 
 	// Additional SSH config fields
 	// Connection and proxy settings

--- a/internal/core/domain/server.go
+++ b/internal/core/domain/server.go
@@ -24,11 +24,11 @@ type Server struct {
 	Port          int
 	IdentityFiles []string
 	Tags          []string
-	LastSeen      time.Time
-	PinnedAt      time.Time
-	SSHCount      int
-	PingStatus    string        // "up", "down", "checking", or ""
-	PingLatency   time.Duration // ping latency
+	LastSeen      time.Time     `lazyssh:"metadata"`
+	PinnedAt      time.Time     `lazyssh:"metadata"`
+	SSHCount      int           `lazyssh:"metadata"`
+	PingStatus    string        `lazyssh:"transient"` // "up", "down", "checking", or ""
+	PingLatency   time.Duration `lazyssh:"transient"` // ping latency
 
 	// Additional SSH config fields
 	// Connection and proxy settings


### PR DESCRIPTION
## Summary
- Add "Ping All" feature with shortcut key `G` to simultaneously check connectivity of all servers
- Implement right-aligned ping status indicators that adapt to terminal width
- Update single server ping (`g`) to display persistent status in the server list
- Fix selection preservation when updating ping status

## Changes
- **New Feature**: Press `G` to ping all visible servers at once
- **UI Enhancement**: Right-aligned status indicators showing:
  - 🟢 Green dot with latency for responsive servers (<100ms shows as "##ms", ≥100ms as "#.#s")
  - 🔴 Red dot with "DOWN" for unreachable servers
  - 🟠 Orange dot with "..." while checking
- **Responsive Design**: Status indicators intelligently adapt based on terminal width:
  - Width > 80: Full status with latency
  - Width 60-80: Status dot only
  - Width < 60: Hidden to preserve content
- **Bug Fix**: Preserve current server selection when ping operations update the display
- **Performance**: Concurrent goroutines for simultaneous pinging without blocking UI

## Testing
- [x] Tested `G` key to ping all servers - confirms all servers are pinged simultaneously
- [x] Tested `g` key for single server ping - updates status correctly
- [x] Verified right-alignment works across different terminal widths
- [x] Confirmed window resize dynamically adjusts indicator position
- [x] Tested with various latencies to verify formatting (<100ms, 100ms-999ms, 1s+)
- [x] Verified UI remains responsive during ping operations
- [x] Confirmed selected server stays highlighted after ping/ping all operations

## Screenshots
The ping status indicators appear right-aligned at the end of each server entry, providing immediate visual feedback on server connectivity without disrupting the current selection.

Closes #30
