### PR TITLE
Restart remote host, connection closed by remote, terminal hangs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,39 @@
+name: Go Build and Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+          cache: true
+
+      - name: Run make build
+        run: make build
+
+      - name: Run make test
+        run: make test

--- a/.github/workflows/semantic-prs.yml
+++ b/.github/workflows/semantic-prs.yml
@@ -1,0 +1,43 @@
+name: Semantic PRs
+
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate_title:
+    name: Validate Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            improve
+            refactor
+            revert
+            test
+            ci
+            docs
+            chore
+
+          scopes: |
+            ui
+            cli
+            config
+            parser
+          requireScope: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,14 @@ issues:
         - dupl
         - lll
 
-
+    # exclude some linters for the test directory and test files
+    - path: test/.*|.*_test\.go
+      linters:
+        - dupl
+        - errcheck
+        - goconst
+        - gocyclo
+        - gosec
 
 linters:
   disable-all: true

--- a/README.md
+++ b/README.md
@@ -200,6 +200,35 @@ Contributions are welcome!
 
 We love seeing the community make Lazyssh better 🚀
 
+### Semantic Pull Requests
+
+This repository enforces semantic PR titles via an automated GitHub Action. Please format your PR title as:
+
+- type(scope): short descriptive subject
+Notes:
+- Scope is optional and should be one of: ui, cli, config, parser.
+
+Allowed types in this repo:
+- feat: a new feature
+- fix: a bug fix
+- improve: quality or UX improvements that are not a refactor or perf
+- refactor: code change that neither fixes a bug nor adds a feature
+- docs: documentation only changes
+- test: adding or refactoring tests
+- ci: CI/CD or automation changes
+- chore: maintenance tasks, dependency bumps, non-code infra
+- revert: reverts a previous commit
+
+Examples:
+- feat(ui): add server pinning and sorting options
+- fix(parser): handle comments at end of Host blocks
+- improve(cli): show friendly error when ssh binary missing
+- refactor(config): simplify backup rotation logic
+- docs: add installation instructions for Homebrew
+- ci: cache Go toolchain and dependencies
+
+Tip: If your PR touches multiple areas, pick the most relevant scope or omit the scope.
+
 ---
 
 ## ⭐ Support

--- a/internal/adapters/ui/validation_test.go
+++ b/internal/adapters/ui/validation_test.go
@@ -15,6 +15,8 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -134,6 +136,29 @@ func TestValidateBindAddress(t *testing.T) {
 }
 
 func TestValidateKeyPaths(t *testing.T) {
+	// Prepare an isolated HOME with a mock .ssh folder and key files
+	oldHome := os.Getenv("HOME")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", oldHome)
+	})
+
+	tempHome := t.TempDir()
+	sshDir := filepath.Join(tempHome, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o755); err != nil {
+		t.Fatalf("failed to create temp .ssh dir: %v", err)
+	}
+
+	shouldExistFiles := []string{"id_rsa", "id_ed25519"}
+	for _, name := range shouldExistFiles {
+		p := filepath.Join(sshDir, name)
+		if err := os.WriteFile(p, []byte("test"), 0o644); err != nil {
+			t.Fatalf("failed to create mock key file %s: %v", p, err)
+		}
+	}
+	if err := os.Setenv("HOME", tempHome); err != nil {
+		t.Fatalf("failed to set HOME: %v", err)
+	}
+
 	tests := []struct {
 		name    string
 		keys    string

--- a/internal/core/services/server_service_test.go
+++ b/internal/core/services/server_service_test.go
@@ -1,0 +1,191 @@
+package services
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/Adembc/lazyssh/internal/core/domain"
+	"github.com/Adembc/lazyssh/internal/core/ports"
+	"go.uber.org/zap/zaptest"
+)
+
+type mockServerRepository struct {
+	ports.ServerRepository
+	recordCalls int
+	lastAlias   string
+	recordErr   error
+}
+
+func (m *mockServerRepository) ListServers(string) ([]domain.Server, error) {
+	return nil, nil
+}
+
+func (m *mockServerRepository) UpdateServer(domain.Server, domain.Server) error { return nil }
+
+func (m *mockServerRepository) AddServer(domain.Server) error { return nil }
+
+func (m *mockServerRepository) DeleteServer(domain.Server) error { return nil }
+
+func (m *mockServerRepository) SetPinned(string, bool) error { return nil }
+
+func (m *mockServerRepository) RecordSSH(alias string) error {
+	m.recordCalls++
+	m.lastAlias = alias
+	return m.recordErr
+}
+
+func helperCommandFactory(scenario string) func(string) *exec.Cmd {
+	return func(alias string) *exec.Cmd {
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", scenario, alias)
+		cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
+		return cmd
+	}
+}
+
+func TestServerServiceSSH_RemoteDisconnect(t *testing.T) {
+	repo := &mockServerRepository{}
+	svc := &serverService{
+		logger:           zaptest.NewLogger(t).Sugar(),
+		serverRepository: repo,
+		newSSHCommand:    helperCommandFactory("remote"),
+	}
+
+	if err := svc.SSH("example"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if repo.recordCalls != 1 {
+		t.Fatalf("expected RecordSSH to be called once, got %d", repo.recordCalls)
+	}
+}
+
+func TestServerServiceSSH_ConnectionReset(t *testing.T) {
+	repo := &mockServerRepository{}
+	svc := &serverService{
+		logger:           zaptest.NewLogger(t).Sugar(),
+		serverRepository: repo,
+		newSSHCommand:    helperCommandFactory("reset"),
+	}
+
+	if err := svc.SSH("example"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if repo.recordCalls != 1 {
+		t.Fatalf("expected RecordSSH to be called once, got %d", repo.recordCalls)
+	}
+}
+
+func TestServerServiceSSH_PermissionDenied(t *testing.T) {
+	repo := &mockServerRepository{}
+	svc := &serverService{
+		logger:           zaptest.NewLogger(t).Sugar(),
+		serverRepository: repo,
+		newSSHCommand:    helperCommandFactory("permission"),
+	}
+
+	if err := svc.SSH("example"); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if repo.recordCalls != 0 {
+		t.Fatalf("expected RecordSSH not to be called, got %d", repo.recordCalls)
+	}
+}
+
+func TestServerServiceSSH_Success(t *testing.T) {
+	repo := &mockServerRepository{}
+	svc := &serverService{
+		logger:           zaptest.NewLogger(t).Sugar(),
+		serverRepository: repo,
+		newSSHCommand:    helperCommandFactory("success"),
+	}
+
+	if err := svc.SSH("example"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if repo.recordCalls != 1 {
+		t.Fatalf("expected RecordSSH to be called once, got %d", repo.recordCalls)
+	}
+}
+
+func TestServerServiceSSH_CommandFactoryReturnsNil(t *testing.T) {
+	repo := &mockServerRepository{}
+	svc := &serverService{
+		logger:           zaptest.NewLogger(t).Sugar(),
+		serverRepository: repo,
+		newSSHCommand: func(string) *exec.Cmd {
+			return nil
+		},
+	}
+
+	err := svc.SSH("example")
+	if err == nil {
+		t.Fatalf("expected error when command factory returns nil")
+	}
+}
+
+func TestIsRemoteDisconnectError(t *testing.T) {
+	if isRemoteDisconnectError(errors.New("plain error"), "Connection closed by remote host") {
+		t.Fatalf("expected non-exit error to return false")
+	}
+
+	cmd := helperCommandFactory("remote")("example")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected error for remote disconnect scenario")
+	}
+	if !isRemoteDisconnectError(err, "Connection to example closed by remote host.\n") {
+		t.Fatalf("expected remote disconnect error to be detected")
+	}
+
+	cmd = helperCommandFactory("permission")("example")
+	err = cmd.Run()
+	if err == nil {
+		t.Fatalf("expected error for permission scenario")
+	}
+	if isRemoteDisconnectError(err, "Permission denied (publickey).\n") {
+		t.Fatalf("did not expect permission error to be treated as disconnect")
+	}
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--" && i+1 < len(args) {
+			scenario := args[i+1]
+			alias := ""
+			if i+2 < len(args) {
+				alias = args[i+2]
+			}
+
+			switch scenario {
+			case "remote":
+				_, _ = os.Stderr.WriteString("Connection to " + alias + " closed by remote host.\n")
+				os.Exit(255)
+			case "reset":
+				_, _ = os.Stderr.WriteString("Read from remote host " + alias + ": Connection reset by peer\n")
+				os.Exit(255)
+			case "permission":
+				_, _ = os.Stderr.WriteString("Permission denied (publickey).\n")
+				os.Exit(255)
+			case "success":
+				os.Exit(0)
+			default:
+				_, _ = os.Stderr.WriteString("unknown scenario\n")
+				os.Exit(1)
+			}
+		}
+	}
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary
- treat ssh exit errors caused by remote disconnects as normal session termination so the TUI resumes cleanly
- capture stderr output safely to detect remote closures and keep recording metadata updates
- add unit tests that exercise remote disconnect, reset, and failure scenarios via helper commands

## Testing
- go test ./...

Fixes issue #40 