### PR TITLE
Ability to hide hosts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,39 @@
+name: Go Build and Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+          cache: true
+
+      - name: Run make build
+        run: make build
+
+      - name: Run make test
+        run: make test

--- a/.github/workflows/semantic-prs.yml
+++ b/.github/workflows/semantic-prs.yml
@@ -1,0 +1,43 @@
+name: Semantic PRs
+
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate_title:
+    name: Validate Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            improve
+            refactor
+            revert
+            test
+            ci
+            docs
+            chore
+
+          scopes: |
+            ui
+            cli
+            config
+            parser
+          requireScope: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,14 @@ issues:
         - dupl
         - lll
 
-
+    # exclude some linters for the test directory and test files
+    - path: test/.*|.*_test\.go
+      linters:
+        - dupl
+        - errcheck
+        - goconst
+        - gocyclo
+        - gosec
 
 linters:
   disable-all: true

--- a/README.md
+++ b/README.md
@@ -200,6 +200,35 @@ Contributions are welcome!
 
 We love seeing the community make Lazyssh better 🚀
 
+### Semantic Pull Requests
+
+This repository enforces semantic PR titles via an automated GitHub Action. Please format your PR title as:
+
+- type(scope): short descriptive subject
+Notes:
+- Scope is optional and should be one of: ui, cli, config, parser.
+
+Allowed types in this repo:
+- feat: a new feature
+- fix: a bug fix
+- improve: quality or UX improvements that are not a refactor or perf
+- refactor: code change that neither fixes a bug nor adds a feature
+- docs: documentation only changes
+- test: adding or refactoring tests
+- ci: CI/CD or automation changes
+- chore: maintenance tasks, dependency bumps, non-code infra
+- revert: reverts a previous commit
+
+Examples:
+- feat(ui): add server pinning and sorting options
+- fix(parser): handle comments at end of Host blocks
+- improve(cli): show friendly error when ssh binary missing
+- refactor(config): simplify backup rotation logic
+- docs: add installation instructions for Homebrew
+- ci: cache Go toolchain and dependencies
+
+Tip: If your PR touches multiple areas, pick the most relevant scope or omit the scope.
+
 ---
 
 ## ⭐ Support

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ With lazyssh, you can quickly navigate, connect, manage, and transfer files betw
 - ✏ Edit existing server entries directly from the UI with a tabbed interface.
 - 🗑 Delete server entries safely.
 - 📌 Pin / unpin servers to keep favorites at the top.
+- 👻 Hide servers you rarely use and toggle their visibility on demand.
 - 🏓 Ping server to check status.
 
 ### Quick Server Navigation

--- a/internal/adapters/data/ssh_config_file/mapper.go
+++ b/internal/adapters/data/ssh_config_file/mapper.go
@@ -295,10 +295,12 @@ func (r *Repository) mapDebugConfig(server *domain.Server, key, value string) bo
 func (r *Repository) mergeMetadata(servers []domain.Server, metadata map[string]ServerMetadata) []domain.Server {
 	for i, server := range servers {
 		servers[i].LastSeen = time.Time{}
+		servers[i].Hidden = false
 
 		if meta, exists := metadata[server.Alias]; exists {
 			servers[i].Tags = meta.Tags
 			servers[i].SSHCount = meta.SSHCount
+			servers[i].Hidden = meta.Hidden
 
 			if meta.LastSeen != "" {
 				if lastSeen, err := time.Parse(time.RFC3339, meta.LastSeen); err == nil {

--- a/internal/adapters/data/ssh_config_file/metadata_manager.go
+++ b/internal/adapters/data/ssh_config_file/metadata_manager.go
@@ -30,6 +30,7 @@ type ServerMetadata struct {
 	LastSeen string   `json:"last_seen,omitempty"`
 	PinnedAt string   `json:"pinned_at,omitempty"`
 	SSHCount int      `json:"ssh_count,omitempty"`
+	Hidden   bool     `json:"hidden,omitempty"`
 }
 
 type metadataManager struct {
@@ -146,6 +147,20 @@ func (m *metadataManager) setPinned(alias string, pinned bool) error {
 	}
 
 	metadata[alias] = meta
+	return m.saveAll(metadata)
+}
+
+func (m *metadataManager) setHidden(alias string, hidden bool) error {
+	metadata, err := m.loadAll()
+	if err != nil {
+		m.logger.Errorw("failed to load metadata in setHidden", "path", m.filePath, "alias", alias, "hidden", hidden, "error", err)
+		return fmt.Errorf("load metadata: %w", err)
+	}
+
+	meta := metadata[alias]
+	meta.Hidden = hidden
+	metadata[alias] = meta
+
 	return m.saveAll(metadata)
 }
 

--- a/internal/adapters/data/ssh_config_file/ssh_config_file_repo.go
+++ b/internal/adapters/data/ssh_config_file/ssh_config_file_repo.go
@@ -160,6 +160,11 @@ func (r *Repository) SetPinned(alias string, pinned bool) error {
 	return r.metadataManager.setPinned(alias, pinned)
 }
 
+// SetHidden sets or unsets the hidden status of a server.
+func (r *Repository) SetHidden(alias string, hidden bool) error {
+	return r.metadataManager.setHidden(alias, hidden)
+}
+
 // RecordSSH increments the SSH access count and updates the last seen timestamp for a server.
 func (r *Repository) RecordSSH(alias string) error {
 	return r.metadataManager.recordSSH(alias)

--- a/internal/adapters/ui/hint_bar.go
+++ b/internal/adapters/ui/hint_bar.go
@@ -22,6 +22,6 @@ import (
 func NewHintBar() *tview.TextView {
 	hint := tview.NewTextView().SetDynamicColors(true)
 	hint.SetBackgroundColor(tcell.Color233)
-	hint.SetText("[#BBBBBB]Press [::b]/[-:-:b] to search…  •  ↑↓ Navigate  •  Enter SSH  •  c Copy SSH  •  g Ping  •  r Refresh  •  a Add  •  e Edit  •  t Tags  •  d Delete  •  p Pin/Unpin  •  s Sort[-]")
+	hint.SetText("[#BBBBBB]Press [::b]/[-:-:b] to search…  •  ↑↓ Navigate  •  Enter SSH  •  c Copy SSH  •  g Ping  •  r Refresh  •  a Add  •  e Edit  •  t Tags  •  d Delete  •  p Pin/Unpin  •  h Hide  •  H Hidden view  •  s Sort[-]")
 	return hint
 }

--- a/internal/adapters/ui/server_details.go
+++ b/internal/adapters/ui/server_details.go
@@ -68,6 +68,10 @@ func (sd *ServerDetails) UpdateServer(server domain.Server) {
 	if server.PinnedAt.IsZero() {
 		pinnedStr = "false"
 	}
+	hiddenStr := "false"
+	if server.Hidden {
+		hiddenStr = "true"
+	}
 	tagsText := renderTagChips(server.Tags)
 
 	// Basic information
@@ -83,9 +87,9 @@ func (sd *ServerDetails) UpdateServer(server domain.Server) {
 	}
 
 	text := fmt.Sprintf(
-		"[::b]%s[-]\n\n[::b]Basic Settings:[-]\n  Host: [white]%s[-]\n  User: [white]%s[-]\n  Port: [white]%s[-]\n  Key:  [white]%s[-]\n  Tags: %s\n  Pinned: [white]%s[-]\n  Last SSH: %s\n  SSH Count: [white]%d[-]\n",
+		"[::b]%s[-]\n\n[::b]Basic Settings:[-]\n  Host: [white]%s[-]\n  User: [white]%s[-]\n  Port: [white]%s[-]\n  Key:  [white]%s[-]\n  Tags: %s\n  Pinned: [white]%s[-]\n  Hidden: [white]%s[-]\n  Last SSH: %s\n  SSH Count: [white]%d[-]\n",
 		aliasText, hostText, userText, portText,
-		serverKey, tagsText, pinnedStr,
+		serverKey, tagsText, pinnedStr, hiddenStr,
 		lastSeen, server.SSHCount)
 
 	// Advanced settings section (only show non-empty fields)
@@ -213,7 +217,7 @@ func (sd *ServerDetails) UpdateServer(server domain.Server) {
 	}
 
 	// Commands list
-	text += "\n[::b]Commands:[-]\n  Enter: SSH connect\n  c: Copy SSH command\n  g: Ping server\n  r: Refresh list\n  a: Add new server\n  e: Edit entry\n  t: Edit tags\n  d: Delete entry\n  p: Pin/Unpin"
+	text += "\n[::b]Commands:[-]\n  Enter: SSH connect\n  c: Copy SSH command\n  g: Ping server\n  r: Refresh list\n  a: Add new server\n  e: Edit entry\n  t: Edit tags\n  d: Delete entry\n  p: Pin/Unpin\n  h: Hide/Unhide\n  H: Toggle hidden view"
 
 	sd.TextView.SetText(text)
 }

--- a/internal/adapters/ui/status_bar.go
+++ b/internal/adapters/ui/status_bar.go
@@ -20,7 +20,7 @@ import (
 )
 
 func DefaultStatusText() string {
-	return "[white]↑↓[-] Navigate  • [white]Enter[-] SSH  • [white]c[-] Copy SSH  • [white]a[-] Add  • [white]e[-] Edit  • [white]g[-] Ping  • [white]d[-] Delete  • [white]p[-] Pin/Unpin  • [white]/[-] Search  • [white]q[-] Quit"
+	return "[white]↑↓[-] Navigate  • [white]Enter[-] SSH  • [white]c[-] Copy SSH  • [white]a[-] Add  • [white]e[-] Edit  • [white]g[-] Ping  • [white]d[-] Delete  • [white]p[-] Pin/Unpin  • [white]h[-] Hide  • [white]H[-] Hidden view  • [white]/[-] Search  • [white]q[-] Quit"
 }
 
 func NewStatusBar() *tview.TextView {

--- a/internal/adapters/ui/utils_test.go
+++ b/internal/adapters/ui/utils_test.go
@@ -171,3 +171,33 @@ func TestBuildSSHCommand_CompleteCommand(t *testing.T) {
 		t.Errorf("Command should contain 'admin@example.com', got: %q", result)
 	}
 }
+
+func TestFilterServersByHidden(t *testing.T) {
+	servers := []domain.Server{
+		{Alias: "a", Hidden: false},
+		{Alias: "b", Hidden: true},
+		{Alias: "c", Hidden: true},
+		{Alias: "d", Hidden: false},
+	}
+
+	filtered, hiddenCount := filterServersByHidden(servers, false)
+	if hiddenCount != 2 {
+		t.Fatalf("expected hiddenCount=2, got %d", hiddenCount)
+	}
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 visible servers, got %d", len(filtered))
+	}
+	for _, srv := range filtered {
+		if srv.Hidden {
+			t.Fatalf("expected filtered servers to exclude hidden ones, got %+v", srv)
+		}
+	}
+
+	filtered, hiddenCount = filterServersByHidden(servers, true)
+	if hiddenCount != 2 {
+		t.Fatalf("expected hiddenCount to remain 2 when including hidden, got %d", hiddenCount)
+	}
+	if len(filtered) != len(servers) {
+		t.Fatalf("expected all servers when including hidden, got %d", len(filtered))
+	}
+}

--- a/internal/adapters/ui/validation_test.go
+++ b/internal/adapters/ui/validation_test.go
@@ -15,6 +15,8 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -134,6 +136,29 @@ func TestValidateBindAddress(t *testing.T) {
 }
 
 func TestValidateKeyPaths(t *testing.T) {
+	// Prepare an isolated HOME with a mock .ssh folder and key files
+	oldHome := os.Getenv("HOME")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", oldHome)
+	})
+
+	tempHome := t.TempDir()
+	sshDir := filepath.Join(tempHome, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o755); err != nil {
+		t.Fatalf("failed to create temp .ssh dir: %v", err)
+	}
+
+	shouldExistFiles := []string{"id_rsa", "id_ed25519"}
+	for _, name := range shouldExistFiles {
+		p := filepath.Join(sshDir, name)
+		if err := os.WriteFile(p, []byte("test"), 0o644); err != nil {
+			t.Fatalf("failed to create mock key file %s: %v", p, err)
+		}
+	}
+	if err := os.Setenv("HOME", tempHome); err != nil {
+		t.Fatalf("failed to set HOME: %v", err)
+	}
+
 	tests := []struct {
 		name    string
 		keys    string

--- a/internal/core/domain/server.go
+++ b/internal/core/domain/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	LastSeen      time.Time
 	PinnedAt      time.Time
 	SSHCount      int
+	Hidden        bool
 
 	// Additional SSH config fields
 	// Connection and proxy settings

--- a/internal/core/ports/repositories.go
+++ b/internal/core/ports/repositories.go
@@ -22,5 +22,6 @@ type ServerRepository interface {
 	AddServer(server domain.Server) error
 	DeleteServer(server domain.Server) error
 	SetPinned(alias string, pinned bool) error
+	SetHidden(alias string, hidden bool) error
 	RecordSSH(alias string) error
 }

--- a/internal/core/ports/services.go
+++ b/internal/core/ports/services.go
@@ -26,6 +26,7 @@ type ServerService interface {
 	AddServer(server domain.Server) error
 	DeleteServer(server domain.Server) error
 	SetPinned(alias string, pinned bool) error
+	SetHidden(alias string, hidden bool) error
 	SSH(alias string) error
 	Ping(server domain.Server) (bool, time.Duration, error)
 }

--- a/internal/core/services/server_service.go
+++ b/internal/core/services/server_service.go
@@ -148,6 +148,15 @@ func (s *serverService) SetPinned(alias string, pinned bool) error {
 	return err
 }
 
+// SetHidden sets or clears the hidden state for the given server alias.
+func (s *serverService) SetHidden(alias string, hidden bool) error {
+	err := s.serverRepository.SetHidden(alias, hidden)
+	if err != nil {
+		s.logger.Errorw("failed to set hidden state", "error", err, "alias", alias, "hidden", hidden)
+	}
+	return err
+}
+
 // SSH starts an interactive SSH session to the given alias using the system's ssh client.
 func (s *serverService) SSH(alias string) error {
 	s.logger.Infow("ssh start", "alias", alias)


### PR DESCRIPTION
## Summary
- add persistent hidden metadata and repository/service plumbing so servers can be hidden without losing config data
- extend the TUI to hide or show entries, surface new shortcuts, and render hidden servers with distinct styling
- update documentation and unit tests to cover hidden filtering behaviour

## Testing
- go test ./...

Fixes issue #32 