### PR TITLE
fix: update github secret variable name

### DIFF
--- a/.github/workflows/semantic-prs.yml
+++ b/.github/workflows/semantic-prs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v5.5.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
             fix


### PR DESCRIPTION
This PR updates the workflow to use the built-in `secrets.GITHUB_TOKEN`.