### PR TITLE
fix(ui): allow at and colon in username

### DIFF
--- a/internal/adapters/ui/validation.go
+++ b/internal/adapters/ui/validation.go
@@ -150,8 +150,8 @@ func GetFieldValidators() map[string]fieldValidator {
 		Message:  "Port must be between 1 and 65535",
 	}
 	validators["User"] = fieldValidator{
-		Pattern: regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9._-]*$`),
-		Message: "User must start with a letter and contain only letters, numbers, dots, hyphens, and underscores",
+		Pattern: regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9.@:_-]*$`),
+		Message: "User must start with a letter and contain only letters, numbers, dots, hyphens, at, colon, and underscores",
 	}
 	validators["Keys"] = fieldValidator{
 		Validate: validateKeyPaths,

--- a/internal/adapters/ui/validation_test.go
+++ b/internal/adapters/ui/validation_test.go
@@ -206,8 +206,14 @@ func TestFieldValidatorPatterns(t *testing.T) {
 
 		// User field
 		{"User", "root", false},
+		{"User", "Username", false},
+		{"User", "userName", false},
+		{"User", "username1", false},
 		{"User", "user_name", false},
 		{"User", "user-name", false},
+		{"User", "user.name", false},
+		{"User", "user@name", false},
+		{"User", "user:name", false},
 		{"User", "1user", true}, // Can't start with number
 
 		// ConnectTimeout field


### PR DESCRIPTION
This PR fix issue #85 by allowing at (@) and colon (:) in the User field