### PR TITLE
feat: Add a shortcut to copy host

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ make run
 | ↑↓/jk | Navigate servers              |
 | Enter | SSH into selected server      |
 | c     | Copy SSH command to clipboard |
+| h     | Copy Host to clipboard |
 | g     | Ping selected server          |
 | r     | Refresh background data       |
 | a     | Add server                    |

--- a/internal/adapters/ui/handlers.go
+++ b/internal/adapters/ui/handlers.go
@@ -71,6 +71,9 @@ func (t *tui) handleGlobalKeys(event *tcell.EventKey) *tcell.EventKey {
 	case 'c':
 		t.handleCopyCommand()
 		return nil
+	case 'h':
+		t.handleCopyHost()
+		return nil
 	case 'g':
 		t.handlePingSelected()
 		return nil
@@ -133,6 +136,17 @@ func (t *tui) handleCopyCommand() {
 		cmd := BuildSSHCommand(server)
 		if err := clipboard.WriteAll(cmd); err == nil {
 			t.showStatusTemp("Copied: " + cmd)
+		} else {
+			t.showStatusTemp("Failed to copy to clipboard")
+		}
+	}
+}
+
+func (t *tui) handleCopyHost() {
+	if server, ok := t.serverList.GetSelectedServer(); ok {
+		host := server.Host
+		if err := clipboard.WriteAll(host); err == nil {
+			t.showStatusTemp("Copied: " + host)
 		} else {
 			t.showStatusTemp("Failed to copy to clipboard")
 		}

--- a/internal/adapters/ui/server_details.go
+++ b/internal/adapters/ui/server_details.go
@@ -213,7 +213,7 @@ func (sd *ServerDetails) UpdateServer(server domain.Server) {
 	}
 
 	// Commands list
-	text += "\n[::b]Commands:[-]\n  Enter: SSH connect\n  f: Port forward\n  x: Stop forwarding\n  c: Copy SSH command\n  g: Ping server\n  r: Refresh list\n  a: Add new server\n  e: Edit entry\n  t: Edit tags\n  d: Delete entry\n  p: Pin/Unpin"
+	text += "\n[::b]Commands:[-]\n  Enter: SSH connect\n  f: Port forward\n  x: Stop forwarding\n  c: Copy SSH command\n  h: Copy Host\n  g: Ping server\n  r: Refresh list\n  a: Add new server\n  e: Edit entry\n  t: Edit tags\n  d: Delete entry\n  p: Pin/Unpin"
 
 	sd.TextView.SetText(text)
 }

--- a/internal/adapters/ui/status_bar.go
+++ b/internal/adapters/ui/status_bar.go
@@ -20,7 +20,7 @@ import (
 )
 
 func DefaultStatusText() string {
-	return "[white]↑↓[-] Navigate  • [white]Enter[-] SSH  • [white]f[-] Forward  • [white]x[-] Stop Forward  • [white]c[-] Copy SSH  • [white]a[-] Add  • [white]e[-] Edit  • [white]g[-] Ping  • [white]d[-] Delete  • [white]p[-] Pin/Unpin  • [white]/[-] Search  • [white]q[-] Quit"
+	return "[white]↑↓[-] Navigate  • [white]Enter[-] SSH  • [white]f[-] Forward  • [white]x[-] Stop Forward  • [white]c[-] Copy SSH  • [white]h[-] Copy Host  • [white]a[-] Add  • [white]e[-] Edit  • [white]g[-] Ping  • [white]d[-] Delete  • [white]p[-] Pin/Unpin  • [white]/[-] Search  • [white]q[-] Quit"
 }
 
 func NewStatusBar() *tview.TextView {


### PR DESCRIPTION
Sometimes we only need to copy the host IP instead of the entire SSH command. This change may benefit those users.