### PR TITLE
feat: add Git SSH key configuration feature (issue #91)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,8 +52,10 @@ func main() {
 	metaDataFile := filepath.Join(home, ".lazyssh", "metadata.json")
 
 	serverRepo := ssh_config_file.NewRepository(log, sshConfigFile, metaDataFile)
-	serverService := services.NewServerService(log, serverRepo)
-	tui := ui.NewTUI(log, serverService, version, gitCommit)
+	gitService := services.NewGitService(log)
+	gitService.SetServerRepository(serverRepo)
+	serverService := services.NewServerService(log, serverRepo, gitService)
+	tui := ui.NewTUI(log, serverService, serverRepo, gitService, version, gitCommit)
 
 	rootCmd := &cobra.Command{
 		Use:   ui.AppName,

--- a/internal/adapters/ui/edit_key_comment.go
+++ b/internal/adapters/ui/edit_key_comment.go
@@ -1,0 +1,162 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// EditKeyComment is a modal dialog for editing SSH key comments.
+type EditKeyComment struct {
+	*tview.Flex
+	app            *tview.Application
+	form           *tview.Form
+	infoText       *tview.TextView
+	keyPath        string
+	keyName        string
+	initialComment string
+	onSave         func(comment string)
+	onCancel       func()
+}
+
+// NewEditKeyComment creates a new comment edit modal.
+func NewEditKeyComment(app *tview.Application) *EditKeyComment {
+	form := tview.NewForm()
+	form.SetBorderPadding(1, 1, 2, 2)
+
+	infoText := tview.NewTextView()
+	infoText.SetDynamicColors(true).
+		SetTextAlign(tview.AlignLeft).
+		SetBorderPadding(1, 1, 2, 2)
+
+	edit := &EditKeyComment{
+		Flex:     tview.NewFlex().SetDirection(tview.FlexRow),
+		app:      app,
+		form:     form,
+		infoText: infoText,
+	}
+
+	edit.AddItem(edit.infoText, 0, 1, false).
+		AddItem(edit.form, 0, 2, true)
+
+	edit.SetBorder(true).
+		SetTitle(" Edit SSH Key Comment ").
+		SetTitleAlign(tview.AlignLeft)
+
+	return edit
+}
+
+// SetKey sets the key name, path, and initial comment for editing.
+func (e *EditKeyComment) SetKey(name, path, comment string) *EditKeyComment {
+	e.keyName = name
+	e.keyPath = path
+	e.initialComment = comment
+	return e
+}
+
+// OnSave sets the callback for when the user saves the comment.
+func (e *EditKeyComment) OnSave(fn func(comment string)) *EditKeyComment {
+	e.onSave = fn
+	return e
+}
+
+// OnCancel sets the callback for when the user cancels.
+func (e *EditKeyComment) OnCancel(fn func()) *EditKeyComment {
+	e.onCancel = fn
+	return e
+}
+
+// Show displays the modal dialog.
+func (e *EditKeyComment) Show() error {
+	// Build info text
+	infoText := fmt.Sprintf("Editing comment for SSH key:\n\n[yellow]%s[-]\n[dim]%s[-]", e.keyName, e.keyPath)
+	e.infoText.SetText(infoText)
+
+	// Clear and rebuild form
+	e.form.Clear(true)
+
+	// Add comment input field with validation
+	e.form.AddInputField("Comment:", e.initialComment, 0,
+		func(textToCheck string, lastChar rune) bool {
+			// Limit to 220 characters
+			return len(textToCheck) <= 220
+		}, nil).
+		SetLabelColor(tcell.ColorWhite).
+		SetFieldBackgroundColor(tcell.Color236)
+
+	// Add buttons
+	e.form.AddButton("Save", func() {
+		e.save()
+	})
+	e.form.AddButton("Cancel", func() {
+		e.cancel()
+	})
+
+	// Set up key bindings
+	e.form.SetInputCapture(e.handleInput)
+
+	// Focus the form
+	e.app.SetFocus(e.form)
+
+	// Set as modal
+	e.app.SetRoot(e, true)
+
+	return nil
+}
+
+func (e *EditKeyComment) handleInput(event *tcell.EventKey) *tcell.EventKey {
+	//nolint:exhaustive // We only handle specific keys, default handles the rest
+	switch event.Key() {
+	case tcell.KeyEscape, tcell.KeyCtrlC:
+		e.cancel()
+		return nil
+	case tcell.KeyCtrlS:
+		e.save()
+		return nil
+	default:
+		// Let the form handle all other input
+		return event
+	}
+}
+
+func (e *EditKeyComment) save() {
+	// Get the comment from the input field (index 0)
+	comment := e.form.GetFormItem(0).(*tview.InputField).GetText()
+
+	// Trim whitespace
+	comment = strings.TrimSpace(comment)
+
+	// Enforce max length
+	if len(comment) > 220 {
+		comment = comment[:220]
+	}
+
+	// Call the save callback
+	if e.onSave != nil {
+		e.onSave(comment)
+	}
+
+	e.cancel()
+}
+
+func (e *EditKeyComment) cancel() {
+	if e.onCancel != nil {
+		e.onCancel()
+	}
+}

--- a/internal/adapters/ui/git_info.go
+++ b/internal/adapters/ui/git_info.go
@@ -1,0 +1,104 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Adembc/lazyssh/internal/core/ports"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type GitInfo struct {
+	*tview.TextView
+	gitService ports.GitService
+	visible    bool
+}
+
+func NewGitInfo(gitService ports.GitService) *GitInfo {
+	info := &GitInfo{
+		TextView:   tview.NewTextView(),
+		gitService: gitService,
+		visible:    false,
+	}
+
+	info.
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignLeft).
+		SetBorder(true).
+		SetTitle(" Git Repository ").
+		SetTitleAlign(tview.AlignLeft).
+		SetBackgroundColor(tcell.Color232).
+		SetBorderColor(tcell.Color238)
+
+	return info
+}
+
+func (g *GitInfo) Update() {
+	if g.gitService == nil {
+		g.visible = false
+		return
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		g.visible = false
+		return
+	}
+
+	if !g.gitService.IsGitRepository(cwd) {
+		g.visible = false
+		return
+	}
+
+	repoPath, err := g.gitService.GetGitRootPath(cwd)
+	if err != nil {
+		g.visible = false
+		return
+	}
+
+	g.visible = true
+
+	// Get push remote URL with remote name
+	remoteName, remoteURL, err := g.gitService.GetPushRemoteURL(repoPath)
+
+	// Get current SSH config
+	sshConfig, _ := g.gitService.GetCurrentGitSSHConfig(repoPath)
+
+	// Build info text
+	repoName := filepath.Base(repoPath)
+
+	// First line: repo name with remote info
+	if err == nil && remoteURL != "" {
+		text := fmt.Sprintf("[yellow]%s[-] ([dim]%s:[-][blue]%s[-])", repoName, remoteName, remoteURL)
+		g.SetText(text)
+	} else {
+		g.SetText(fmt.Sprintf("[yellow]%s[-]", repoName))
+	}
+
+	// Second line: SSH configured message
+	if sshConfig != "" {
+		g.SetText(g.GetText(false) + "\n[green]✓[-] SSH configured")
+	} else {
+		g.SetText(g.GetText(false) + "\n[dim]Press G to configure SSH[-]")
+	}
+}
+
+func (g *GitInfo) IsVisible() bool {
+	return g.visible
+}

--- a/internal/adapters/ui/git_ssh_setup.go
+++ b/internal/adapters/ui/git_ssh_setup.go
@@ -1,0 +1,285 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Adembc/lazyssh/internal/core/ports"
+	"github.com/Adembc/lazyssh/internal/core/services"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type GitSSHSetup struct {
+	*tview.Flex
+	app        *tview.Application
+	gitService ports.GitService
+	serverRepo ports.ServerRepository
+	form       *tview.Form
+	infoText   *tview.TextView
+	onDone     func()
+	onCancel   func()
+
+	selectedKey   string
+	selectedScope string
+	keys          []ports.SSHKey
+	repoPath      string
+}
+
+func NewGitSSHSetup(app *tview.Application, gitService ports.GitService, serverRepo ports.ServerRepository) *GitSSHSetup {
+	setup := &GitSSHSetup{
+		Flex:       tview.NewFlex().SetDirection(tview.FlexRow),
+		app:        app,
+		gitService: gitService,
+		serverRepo: serverRepo,
+		form:       tview.NewForm(),
+		infoText:   tview.NewTextView(),
+	}
+
+	setup.infoText.
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignLeft).
+		SetBorderPadding(1, 1, 2, 2)
+
+	setup.form.SetBorderPadding(1, 1, 2, 2)
+
+	setup.AddItem(setup.infoText, 0, 1, false).
+		AddItem(setup.form, 0, 2, true)
+
+	setup.SetBorder(true).
+		SetTitle(" Configure Git SSH Key ").
+		SetTitleAlign(tview.AlignLeft)
+
+	return setup
+}
+
+func (g *GitSSHSetup) OnDone(handler func()) *GitSSHSetup {
+	g.onDone = handler
+	return g
+}
+
+func (g *GitSSHSetup) OnCancel(handler func()) *GitSSHSetup {
+	g.onCancel = handler
+	return g
+}
+
+func (g *GitSSHSetup) Show() error {
+	// Get current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Check if we're in a git repository
+	if !g.gitService.IsGitRepository(cwd) {
+		return fmt.Errorf("not in a git repository")
+	}
+
+	// Get the git root path
+	repoPath, err := g.gitService.GetGitRootPath(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to get git root path: %w", err)
+	}
+	g.repoPath = repoPath
+
+	// Get current SSH config
+	currentConfig, _ := g.gitService.GetCurrentGitSSHConfig(repoPath)
+
+	// List available SSH keys
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+	sshDir := filepath.Join(homeDir, ".ssh")
+
+	keys, err := g.gitService.ListSSHKeys(sshDir, g.serverRepo)
+	if err != nil {
+		return fmt.Errorf("failed to list SSH keys: %w", err)
+	}
+	g.keys = keys
+
+	if len(keys) == 0 {
+		return fmt.Errorf("no SSH keys found in %s", sshDir)
+	}
+
+	// Build info text
+	info := fmt.Sprintf("[yellow]Git Repository:[-] %s\n\n", repoPath)
+	if currentConfig != "" {
+		info += fmt.Sprintf("[green]Current SSH Config:[-]\n%s\n\n", currentConfig)
+	} else {
+		info += "[dim]No SSH key configured for Git[-]\n\n"
+	}
+
+	// Count keys in agent
+	keysInAgent := 0
+	for _, key := range keys {
+		if key.InAgent {
+			keysInAgent++
+		}
+	}
+	if keysInAgent > 0 {
+		info += fmt.Sprintf("[green]%d key(s) loaded in ssh-agent/keychain[-]\n\n", keysInAgent)
+	}
+
+	info += "Select an SSH key to use for Git operations in this repository.\n"
+	info += "The configuration will be saved using [yellow]git config core.sshCommand[-]."
+
+	g.infoText.SetText(info)
+
+	// Build form
+	g.form.Clear(true)
+
+	// Add key dropdown
+	keyOptions := make([]string, len(keys))
+	for i, key := range keys {
+		status := ""
+		switch {
+		case key.InAgent:
+			status = " [green](in agent)[-]"
+		case !key.HasPubKey:
+			status = " [red](no .pub)[-]"
+		case key.IsEncrypted:
+			status = " [yellow](encrypted)[-]"
+		}
+		keyOptions[i] = fmt.Sprintf("%s%s", key.Name, status)
+	}
+
+	g.form.AddDropDown("SSH Key", keyOptions, 0, func(option string, optionIndex int) {
+		if optionIndex >= 0 && optionIndex < len(g.keys) {
+			g.selectedKey = g.keys[optionIndex].Path
+		}
+	})
+
+	// Add scope dropdown
+	scopeOptions := []string{"local (this repository only)", "global (all repositories)"}
+	g.form.AddDropDown("Scope", scopeOptions, 0, func(option string, optionIndex int) {
+		if optionIndex == 0 {
+			g.selectedScope = services.ScopeLocal
+		} else {
+			g.selectedScope = services.ScopeGlobal
+		}
+	})
+
+	// Set initial values
+	if len(g.keys) > 0 {
+		g.selectedKey = g.keys[0].Path
+	}
+	g.selectedScope = services.ScopeLocal
+
+	// Add buttons
+	g.form.AddButton("Configure", func() {
+		if err := g.gitService.ConfigureGitSSHKey(g.repoPath, g.selectedKey, g.selectedScope); err != nil {
+			// Show error modal
+			errorModal := tview.NewModal().
+				SetText(fmt.Sprintf("Configuration failed:\n%v", err)).
+				AddButtons([]string{"OK"}).
+				SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+					g.app.SetRoot(g, true)
+					g.app.SetFocus(g.form)
+				})
+			g.app.SetRoot(errorModal, true)
+			return
+		}
+
+		// Show success modal
+		successModal := tview.NewModal().
+			SetText(fmt.Sprintf("Git configured successfully!\n\nSSH Key: %s\nScope: %s",
+				filepath.Base(g.selectedKey), g.selectedScope)).
+			AddButtons([]string{"OK"}).
+			SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+				if g.onDone != nil {
+					g.onDone()
+				}
+			})
+		g.app.SetRoot(successModal, true)
+	})
+
+	// Add "Clear Configuration" button if there's an existing config
+	if currentConfig != "" {
+		g.form.AddButton("Clear Configuration", func() {
+			// Show confirmation modal
+			confirmModal := tview.NewModal().
+				SetText("Clear Git SSH configuration?\n\nThis will reset Git to use default SSH behavior.").
+				AddButtons([]string{"Cancel", "Clear Local", "Clear Both"}).
+				SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+					if buttonIndex == 0 {
+						// Cancel - return to setup form
+						g.app.SetRoot(g, true)
+						g.app.SetFocus(g.form)
+						return
+					}
+
+					scope := services.ScopeLocal
+					if buttonIndex == 2 {
+						scope = services.ScopeBoth
+					}
+
+					// Clear the configuration
+					if err := g.gitService.ClearGitSSHConfig(g.repoPath, scope); err != nil {
+						errorModal := tview.NewModal().
+							SetText(fmt.Sprintf("Failed to clear configuration:\n%v", err)).
+							AddButtons([]string{"OK"}).
+							SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+								g.app.SetRoot(g, true)
+								g.app.SetFocus(g.form)
+							})
+						g.app.SetRoot(errorModal, true)
+						return
+					}
+
+					// Show success modal
+					scopeText := "local"
+					if scope == services.ScopeBoth {
+						scopeText = "local and global"
+					}
+					successModal := tview.NewModal().
+						SetText(fmt.Sprintf("Git SSH configuration cleared!\n\nScope: %s\n\nGit will now use default SSH behavior.", scopeText)).
+						AddButtons([]string{"OK"}).
+						SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+							if g.onDone != nil {
+								g.onDone()
+							}
+						})
+					g.app.SetRoot(successModal, true)
+				})
+			g.app.SetRoot(confirmModal, true)
+		})
+	}
+
+	g.form.AddButton("Cancel", func() {
+		if g.onCancel != nil {
+			g.onCancel()
+		}
+	})
+
+	// Handle keyboard shortcuts
+	g.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEsc {
+			if g.onCancel != nil {
+				g.onCancel()
+			}
+			return nil
+		}
+		return event
+	})
+
+	g.app.SetRoot(g, true)
+	g.app.SetFocus(g.form)
+
+	return nil
+}

--- a/internal/adapters/ui/handlers.go
+++ b/internal/adapters/ui/handlers.go
@@ -16,6 +16,8 @@ package ui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -37,6 +39,7 @@ const (
 	ForwardModeForwardSSH  = "Forward + SSH"
 )
 
+//nolint:gocyclo // High complexity due to many key bindings - acceptable for this handler
 func (t *tui) handleGlobalKeys(event *tcell.EventKey) *tcell.EventKey {
 	// Don't handle global keys when search has focus
 	if t.app.GetFocus() == t.searchBar {
@@ -92,10 +95,59 @@ func (t *tui) handleGlobalKeys(event *tcell.EventKey) *tcell.EventKey {
 	case 'k':
 		t.handleNavigateUp()
 		return nil
+	case 'l':
+		if t.currentPanel == 1 {
+			t.handleLoadKey()
+			return nil
+		}
+		// Also handle 'l' key for loading server's SSH key
+		if t.currentPanel == 0 {
+			t.handleLoadServerKey()
+			return nil
+		}
+	case 'u':
+		if t.currentPanel == 1 {
+			t.handleUnloadKey()
+			return nil
+		}
+		// Also handle 'u' key for unloading server's SSH key
+		if t.currentPanel == 0 {
+			t.handleUnloadServerKey()
+			return nil
+		}
+	case 'G':
+		t.handleGitSSHSetup()
+		return nil
+	}
+
+	// Handle 'C' key (Shift+c) for editing SSH key comment
+	if event.Rune() == 'C' {
+		if t.currentPanel == 1 {
+			t.handleEditKeyComment()
+			return nil
+		}
+		if t.currentPanel == 0 {
+			t.handleEditServerKeyComment()
+			return nil
+		}
 	}
 
 	if event.Key() == tcell.KeyEnter {
+		if t.currentPanel != 0 {
+			// Enter key on SSH Keys panels - no action for now
+			return nil
+		}
 		t.handleServerConnect()
+		return nil
+	}
+
+	if event.Key() == tcell.KeyTab {
+		t.handleTabSwitch()
+		return nil
+	}
+
+	if event.Key() == tcell.KeyBacktab {
+		t.handleTabSwitch()
 		return nil
 	}
 
@@ -146,26 +198,101 @@ func (t *tui) handleTagsEdit() {
 }
 
 func (t *tui) handleNavigateDown() {
-	if t.app.GetFocus() == t.serverList {
-		currentIdx := t.serverList.GetCurrentItem()
-		itemCount := t.serverList.GetItemCount()
+	var currentIdx, itemCount int
+
+	switch t.currentPanel {
+	case 0:
+		// Navigate in Servers panel
+		currentIdx = t.serverList.GetCurrentItem()
+		itemCount = t.serverList.GetItemCount()
 		if currentIdx < itemCount-1 {
 			t.serverList.SetCurrentItem(currentIdx + 1)
 		} else {
 			t.serverList.SetCurrentItem(0)
 		}
+	case 1:
+		// Navigate in SSH Agent panel
+		currentIdx = t.sshAgentKeysList.GetCurrentItem()
+		itemCount = t.sshAgentKeysList.GetItemCount()
+		if currentIdx < itemCount-1 {
+			t.sshAgentKeysList.SetCurrentItem(currentIdx + 1)
+		} else {
+			t.sshAgentKeysList.SetCurrentItem(0)
+		}
 	}
 }
 
 func (t *tui) handleNavigateUp() {
-	if t.app.GetFocus() == t.serverList {
-		currentIdx := t.serverList.GetCurrentItem()
+	var currentIdx, itemCount int
+
+	switch t.currentPanel {
+	case 0:
+		// Navigate in Servers panel
+		currentIdx = t.serverList.GetCurrentItem()
+		itemCount = t.serverList.GetItemCount()
 		if currentIdx > 0 {
 			t.serverList.SetCurrentItem(currentIdx - 1)
 		} else {
-			t.serverList.SetCurrentItem(t.serverList.GetItemCount() - 1)
+			t.serverList.SetCurrentItem(itemCount - 1)
+		}
+	case 1:
+		// Navigate in SSH Agent panel
+		currentIdx = t.sshAgentKeysList.GetCurrentItem()
+		itemCount = t.sshAgentKeysList.GetItemCount()
+		if currentIdx > 0 {
+			t.sshAgentKeysList.SetCurrentItem(currentIdx - 1)
+		} else {
+			t.sshAgentKeysList.SetCurrentItem(itemCount - 1)
 		}
 	}
+}
+
+func (t *tui) handleTabSwitch() {
+	// Cycle through panels: 0 (Servers) → 1 (SSH Agent) → 0
+	t.currentPanel = (t.currentPanel + 1) % 2
+
+	// Update focus to the new panel
+	switch t.currentPanel {
+	case 0:
+		t.app.SetFocus(t.serverList)
+		if server, ok := t.serverList.GetSelectedServer(); ok {
+			t.serverDetails.UpdateServer(server)
+		}
+	case 1:
+		t.app.SetFocus(t.sshAgentKeysList)
+		if key, ok := t.sshAgentKeysList.GetSelectedKey(); ok {
+			t.sshKeyDetails.UpdateKey(key)
+		}
+	}
+
+	t.updatePanelBorders()
+	t.updateRightPanel()
+}
+
+func (t *tui) handlePanelClick(panelIndex int) {
+	// If clicking on the already-focused panel, do nothing
+	if t.currentPanel == panelIndex {
+		return
+	}
+
+	// Switch focus to the clicked panel
+	t.currentPanel = panelIndex
+
+	switch t.currentPanel {
+	case 0:
+		t.app.SetFocus(t.serverList)
+		if server, ok := t.serverList.GetSelectedServer(); ok {
+			t.serverDetails.UpdateServer(server)
+		}
+	case 1:
+		t.app.SetFocus(t.sshAgentKeysList)
+		if key, ok := t.sshAgentKeysList.GetSelectedKey(); ok {
+			t.sshKeyDetails.UpdateKey(key)
+		}
+	}
+
+	t.updatePanelBorders()
+	t.updateRightPanel()
 }
 
 func (t *tui) handleSearchInput(query string) {
@@ -173,7 +300,7 @@ func (t *tui) handleSearchInput(query string) {
 	sortServersForUI(filtered, t.sortMode)
 	t.serverList.UpdateServers(filtered)
 	if len(filtered) == 0 {
-		t.details.ShowEmpty()
+		t.serverDetails.ShowEmpty()
 	}
 }
 
@@ -209,7 +336,7 @@ func (t *tui) handleSearchNavigate(direction int) {
 		}
 
 		if server, ok := t.serverList.GetSelectedServer(); ok {
-			t.details.UpdateServer(server)
+			t.serverDetails.UpdateServer(server)
 		}
 	}
 }
@@ -231,7 +358,13 @@ func (t *tui) handleServerConnect() {
 }
 
 func (t *tui) handleServerSelectionChange(server domain.Server) {
-	t.details.UpdateServer(server)
+	t.serverDetails.UpdateServer(server)
+}
+
+func (t *tui) handleSSHKeySelectionChange(key domain.SSHKey) {
+	if t.sshKeyDetails != nil {
+		t.sshKeyDetails.UpdateKey(key)
+	}
 }
 
 func (t *tui) handleServerAdd() {
@@ -289,6 +422,7 @@ func (t *tui) handleFormCancel() {
 
 func (t *tui) handlePingSelected() {
 	if server, ok := t.serverList.GetSelectedServer(); ok {
+
 		alias := server.Alias
 
 		t.showStatusTemp(fmt.Sprintf("Pinging %s…", alias))
@@ -310,6 +444,7 @@ func (t *tui) handlePingSelected() {
 }
 
 func (t *tui) handleModalClose() {
+	t.updateGitInfoPanel()
 	t.returnToMain()
 }
 
@@ -339,7 +474,7 @@ func (t *tui) handleRefreshBackground() {
 			if prevIdx >= 0 && prevIdx < t.serverList.List.GetItemCount() {
 				t.serverList.SetCurrentItem(prevIdx)
 				if srv, ok := t.serverList.GetSelectedServer(); ok {
-					t.details.UpdateServer(srv)
+					t.serverDetails.UpdateServer(srv)
 				}
 			}
 			t.showStatusTemp(fmt.Sprintf("Refreshed %d servers", len(servers)))
@@ -573,20 +708,6 @@ func (t *tui) blurSearchBar() {
 // Internal Operations (perform actual work)
 // =============================================================================
 
-func (t *tui) refreshServerList() {
-	query := ""
-	if t.searchBar != nil {
-		query = t.searchBar.InputField.GetText()
-	}
-	filtered, _ := t.serverService.ListServers(query)
-	sortServersForUI(filtered, t.sortMode)
-	t.serverList.UpdateServers(filtered)
-}
-
-func (t *tui) returnToMain() {
-	t.app.SetRoot(t.root, true)
-}
-
 // showStatusTemp displays a temporary message in the status bar (default green) and then restores the default text.
 func (t *tui) showStatusTemp(msg string) {
 	if t.statusBar == nil {
@@ -628,4 +749,430 @@ func (t *tui) handleStopForwarding() {
 			})
 		}()
 	}
+}
+
+func (t *tui) handleLoadKey() {
+	if t.gitService == nil {
+		t.showStatusTempColor("Git service not available", "#FF6B6B")
+		return
+	}
+
+	// Get selected key from SSH Agent panel
+	key, ok := t.sshAgentKeysList.GetSelectedKey()
+	if !ok {
+		t.showStatusTempColor("No SSH key selected", "#FF6B6B")
+		return
+	}
+
+	if key.LoadedInAgent {
+		t.showStatusTempColor("Key already loaded in ssh-agent", "#FFA500")
+		return
+	}
+
+	t.showStatusTemp(fmt.Sprintf("Loading key %s...", key.Name))
+
+	// LoadKeyToAgent needs user interaction for passphrase
+	// Suspend is blocking, so we can do this synchronously
+	keyPath := key.Path
+	keyName := key.Name
+
+	t.app.Suspend(func() {
+		err := t.gitService.LoadKeyToAgent(keyPath)
+		if err != nil {
+			fmt.Printf("\nFailed to load key: %v\n", err)
+			fmt.Print("Press Enter to continue...")
+			var dummy string
+			_, _ = fmt.Scanln(&dummy)
+		}
+	})
+
+	// Refresh SSH keys list after load (back in main thread)
+	t.refreshSSHKeysList()
+	t.showStatusTemp(fmt.Sprintf("Key %s loaded successfully", keyName))
+}
+
+func (t *tui) handleUnloadKey() {
+	if t.gitService == nil {
+		t.showStatusTempColor("Git service not available", "#FF6B6B")
+		return
+	}
+
+	// Get selected key from SSH Agent panel
+	key, ok := t.sshAgentKeysList.GetSelectedKey()
+	if !ok {
+		t.showStatusTempColor("No SSH key selected", "#FF6B6B")
+		return
+	}
+
+	if !key.LoadedInAgent {
+		t.showStatusTempColor("Key not loaded in ssh-agent", "#FFA500")
+		return
+	}
+
+	if key.PublicKeyLine == "" {
+		t.showStatusTempColor("Key has no public key line, cannot unload", "#FF6B6B")
+		return
+	}
+
+	t.showStatusTemp(fmt.Sprintf("Unloading key %s...", key.Name))
+
+	go func(publicKeyLine string, keyName string) {
+		err := t.gitService.UnloadKeyFromAgent(publicKeyLine)
+		t.app.QueueUpdateDraw(func() {
+			if err != nil {
+				// Store error for printing at exit
+				t.storeErrorf("[Unload SSH Key] Failed to unload key '%s': %v", keyName, err)
+				t.showStatusTempColor(fmt.Sprintf("Failed to unload key: %v", err), "#FF6B6B")
+			} else {
+				t.refreshSSHKeysList()
+				t.showStatusTemp(fmt.Sprintf("Key %s unloaded successfully", keyName))
+			}
+		})
+	}(key.PublicKeyLine, key.Name)
+}
+
+// handleLoadServerKey loads the SSH key associated with the selected server.
+func (t *tui) handleLoadServerKey() {
+	if t.gitService == nil {
+		t.showStatusTempColor("Git service not available", "#FF6B6B")
+		return
+	}
+
+	// Get selected server from Servers panel
+	server, ok := t.serverList.GetSelectedServer()
+	if !ok {
+		t.showStatusTempColor("No server selected", "#FF6B6B")
+		return
+	}
+
+	// Get the server's SSH key
+	sshKey := t.getSSHKeyForServer(server)
+	if sshKey == nil {
+		t.showStatusTempColor("No SSH key found for this server", "#FF6B6B")
+		return
+	}
+
+	if sshKey.LoadedInAgent {
+		t.showStatusTempColor("Key already loaded in ssh-agent", "#FFA500")
+		return
+	}
+
+	t.showStatusTemp(fmt.Sprintf("Loading key %s...", sshKey.Name))
+
+	// LoadKeyToAgent needs user interaction for passphrase
+	// Suspend is blocking, so we can do this synchronously
+	keyPath := sshKey.Path
+	keyName := sshKey.Name
+
+	t.app.Suspend(func() {
+		err := t.gitService.LoadKeyToAgent(keyPath)
+		if err != nil {
+			// Store error for printing at exit
+			t.storeErrorf("[Load Server SSH Key] Failed to load key '%s' (path: %s): %v", keyName, keyPath, err)
+			fmt.Printf("\nFailed to load key: %v\n", err)
+			fmt.Print("Press Enter to continue...")
+			var dummy string
+			_, _ = fmt.Scanln(&dummy)
+		}
+	})
+
+	// Refresh UI after load (back in main thread)
+	t.refreshServerList() // Refresh to update key status in server details
+	t.refreshSSHKeysList()
+	t.showStatusTemp(fmt.Sprintf("Key %s loaded successfully", keyName))
+}
+
+// handleUnloadServerKey unloads the SSH key associated with the selected server.
+func (t *tui) handleUnloadServerKey() {
+	if t.gitService == nil {
+		t.showStatusTempColor("Git service not available", "#FF6B6B")
+		return
+	}
+
+	// Get selected server from Servers panel
+	server, ok := t.serverList.GetSelectedServer()
+	if !ok {
+		t.showStatusTempColor("No server selected", "#FF6B6B")
+		return
+	}
+
+	// Get the server's SSH key
+	sshKey := t.getSSHKeyForServer(server)
+	if sshKey == nil {
+		t.showStatusTempColor("No SSH key found for this server", "#FF6B6B")
+		return
+	}
+
+	if !sshKey.LoadedInAgent {
+		t.showStatusTempColor("Key not loaded in ssh-agent", "#FFA500")
+		return
+	}
+
+	if sshKey.PublicKeyLine == "" {
+		t.showStatusTempColor("Key has no public key line, cannot unload", "#FF6B6B")
+		return
+	}
+
+	t.showStatusTemp(fmt.Sprintf("Unloading key %s...", sshKey.Name))
+
+	go func(publicKeyLine string, keyName string) {
+		err := t.gitService.UnloadKeyFromAgent(publicKeyLine)
+		t.app.QueueUpdateDraw(func() {
+			if err != nil {
+				// Store error for printing at exit
+				t.storeErrorf("[Unload Server SSH Key] Failed to unload key '%s': %v", keyName, err)
+				t.showStatusTempColor(fmt.Sprintf("Failed to unload key: %v", err), "#FF6B6B")
+			} else {
+				t.refreshServerList() // Refresh to update key status in server details
+				t.refreshSSHKeysList()
+				t.showStatusTemp(fmt.Sprintf("Key %s unloaded successfully", keyName))
+			}
+		})
+	}(sshKey.PublicKeyLine, sshKey.Name)
+}
+
+// getSSHKeyForServer gets the SSH key associated with a server.
+func (t *tui) getSSHKeyForServer(server domain.Server) *domain.SSHKey {
+	if t.gitService == nil || t.serverRepo == nil {
+		return nil
+	}
+
+	// Get the first identity file if available
+	if len(server.IdentityFiles) == 0 {
+		return nil
+	}
+
+	identityFile := server.IdentityFiles[0]
+
+	// Expand ~ to home directory for comparison
+	if strings.HasPrefix(identityFile, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err == nil {
+			identityFile = filepath.Join(homeDir, identityFile[2:])
+		}
+	} else if identityFile == "~" {
+		homeDir, err := os.UserHomeDir()
+		if err == nil {
+			identityFile = homeDir
+		}
+	}
+
+	// Fetch all SSH keys and find the one matching this identity file
+	allKeys, err := t.gitService.ListAllSSHKeys(t.serverRepo)
+	if err != nil {
+		return nil
+	}
+
+	for _, key := range allKeys {
+		if key.Path == identityFile {
+			return &key
+		}
+	}
+
+	return nil
+}
+
+func (t *tui) handleGitSSHSetup() {
+	if t.gitService == nil {
+		t.showStatusTempColor("Git service not available", "#FF6B6B")
+		return
+	}
+
+	setup := NewGitSSHSetup(t.app, t.gitService, t.serverRepo).
+		OnDone(t.handleModalClose).
+		OnCancel(t.handleModalClose)
+
+	if err := setup.Show(); err != nil {
+		modal := tview.NewModal().
+			SetText(fmt.Sprintf("Cannot setup Git SSH key:\n\n%v", err)).
+			AddButtons([]string{"OK"}).
+			SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+				t.handleModalClose()
+			})
+		t.app.SetRoot(modal, true)
+	}
+}
+
+// handleEditKeyComment opens the modal for editing SSH key comments.
+func (t *tui) handleEditKeyComment() {
+	if t.gitService == nil {
+		t.showStatusTempColor("Git service not available", "#FF6B6B")
+		return
+	}
+
+	// Get the currently displayed key from SSHKeyDetails
+	key := t.sshKeyDetails.GetCurrentKey()
+	if key == nil {
+		t.showStatusTempColor("No SSH key selected", "#FF6B6B")
+		return
+	}
+
+	// Only allow editing keys with a known file path
+	if key.Path == "" {
+		t.showStatusTempColor("Cannot edit comment for keys without a file path", "#FFA500")
+		return
+	}
+
+	editor := NewEditKeyComment(t.app).
+		SetKey(key.Name, key.Path, key.Comment).
+		OnSave(func(newComment string) {
+			// For encrypted keys, suspend TUI to allow passphrase input
+			if key.IsEncrypted {
+				t.app.Suspend(func() {
+					if err := t.gitService.UpdateKeyComment(key.Path, newComment); err != nil {
+						fmt.Printf("\nFailed to update comment: %v\n", err)
+						fmt.Print("Press Enter to continue...")
+						var dummy string
+						_, _ = fmt.Scanln(&dummy)
+					}
+				})
+				// Refresh after suspend (back in main thread)
+				t.refreshSSHKeysList()
+				t.showStatusTemp("SSH key comment updated successfully")
+			} else {
+				// For unencrypted keys, update directly
+				if err := t.gitService.UpdateKeyComment(key.Path, newComment); err != nil {
+					t.storeErrorf("[Edit SSH Key Comment] Failed to update comment for '%s': %v", key.Name, err)
+					t.showStatusTempColor(fmt.Sprintf("Failed to update comment: %v", err), "#FF6B6B")
+				} else {
+					t.showStatusTemp("SSH key comment updated successfully")
+					// Refresh the SSH keys list to show the updated comment
+					t.refreshSSHKeysList()
+				}
+			}
+		}).
+		OnCancel(t.handleModalClose)
+
+	if err := editor.Show(); err != nil {
+		modal := tview.NewModal().
+			SetText(fmt.Sprintf("Cannot edit SSH key comment:\n\n%v", err)).
+			AddButtons([]string{"OK"}).
+			SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+				t.handleModalClose()
+			})
+		t.app.SetRoot(modal, true)
+	}
+}
+
+// handleEditServerKeyComment opens the modal for editing the SSH key comment of the selected server.
+func (t *tui) handleEditServerKeyComment() {
+	if t.gitService == nil {
+		t.showStatusTempColor("Git service not available", "#FF6B6B")
+		return
+	}
+
+	// Get the selected server
+	server, ok := t.serverList.GetSelectedServer()
+	if !ok {
+		t.showStatusTempColor("No server selected", "#FF6B6B")
+		return
+	}
+
+	// Get the SSH key for this server
+	sshKey := t.getSSHKeyForServer(server)
+	if sshKey == nil {
+		t.showStatusTempColor("No SSH key found for this server", "#FF6B6B")
+		return
+	}
+
+	// Only allow editing keys with a known file path
+	if sshKey.Path == "" {
+		t.showStatusTempColor("Cannot edit comment for keys without a file path", "#FFA500")
+		return
+	}
+
+	// Remember if the key was loaded before editing
+	wasLoaded := sshKey.LoadedInAgent
+
+	editor := NewEditKeyComment(t.app).
+		SetKey(sshKey.Name, sshKey.Path, sshKey.Comment).
+		OnSave(func(newComment string) {
+			// For encrypted keys, suspend TUI to allow passphrase input
+			if sshKey.IsEncrypted {
+				t.app.Suspend(func() {
+					if err := t.gitService.UpdateKeyComment(sshKey.Path, newComment); err != nil {
+						fmt.Printf("\nFailed to update comment: %v\n", err)
+						fmt.Print("Press Enter to continue...")
+						var dummy string
+						_, _ = fmt.Scanln(&dummy)
+					}
+				})
+			} else {
+				// For unencrypted keys, update directly
+				if err := t.gitService.UpdateKeyComment(sshKey.Path, newComment); err != nil {
+					t.storeErrorf("[Edit SSH Key Comment] Failed to update comment for '%s': %v", sshKey.Name, err)
+					t.showStatusTempColor(fmt.Sprintf("Failed to update comment: %v", err), "#FF6B6B")
+					return
+				}
+			}
+
+			// If the key was loaded in the agent, we need to unload and reload it
+			// to get the fresh comment
+			if wasLoaded {
+				// Unload the key from agent
+				if sshKey.PublicKeyLine != "" {
+					if err := t.gitService.UnloadKeyFromAgent(sshKey.PublicKeyLine); err != nil {
+						t.storeErrorf("[Edit SSH Key Comment] Failed to unload key: %v", err)
+					}
+				}
+
+				t.showStatusTemp("SSH key comment updated! Press 'l' to reload the key in ssh-agent.")
+			} else {
+				t.showStatusTemp("SSH key comment updated successfully")
+			}
+
+			// Refresh the server details to show the updated comment
+			if server, ok := t.serverList.GetSelectedServer(); ok {
+				t.serverDetails.UpdateServer(server)
+			}
+			// Also refresh SSH keys list
+			t.refreshSSHKeysList()
+		}).
+		OnCancel(t.handleModalClose)
+
+	if err := editor.Show(); err != nil {
+		modal := tview.NewModal().
+			SetText(fmt.Sprintf("Cannot edit SSH key comment:\n\n%v", err)).
+			AddButtons([]string{"OK"}).
+			SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+				t.handleModalClose()
+			})
+		t.app.SetRoot(modal, true)
+	}
+}
+
+func (t *tui) refreshServerList() {
+	query := ""
+	if t.searchBar != nil {
+		query = t.searchBar.InputField.GetText()
+	}
+	filtered, _ := t.serverService.ListServers(query)
+
+	sortServersForUI(filtered, t.sortMode)
+	t.serverList.UpdateServers(filtered)
+}
+
+func (t *tui) refreshSSHKeysList() {
+	if t.gitService == nil {
+		return
+	}
+
+	// Refresh agent keys
+	agentKeys, err := t.gitService.ListSSHKeysFromAgent()
+	if err != nil {
+		t.showStatusTempColor(fmt.Sprintf("Failed to refresh SSH agent keys: %v", err), "#FF6B6B")
+	} else {
+		t.sshAgentKeysList.UpdateKeys(agentKeys)
+	}
+
+	// Update details for current selection if on SSH Agent panel
+	if t.currentPanel == 1 {
+		if key, ok := t.sshAgentKeysList.GetSelectedKey(); ok {
+			t.sshKeyDetails.UpdateKey(key)
+		}
+	}
+}
+
+func (t *tui) returnToMain() {
+	t.app.SetRoot(t.root, true)
 }

--- a/internal/adapters/ui/server_details.go
+++ b/internal/adapters/ui/server_details.go
@@ -16,20 +16,27 @@ package ui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Adembc/lazyssh/internal/core/domain"
+	"github.com/Adembc/lazyssh/internal/core/ports"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
 type ServerDetails struct {
 	*tview.TextView
+	gitService ports.GitService
+	serverRepo ports.ServerRepository
 }
 
-func NewServerDetails() *ServerDetails {
+func NewServerDetails(gitService ports.GitService, serverRepo ports.ServerRepository) *ServerDetails {
 	details := &ServerDetails{
-		TextView: tview.NewTextView(),
+		TextView:   tview.NewTextView(),
+		gitService: gitService,
+		serverRepo: serverRepo,
 	}
 	details.build()
 	return details
@@ -55,6 +62,47 @@ func renderTagChips(tags []string) string {
 		chips = append(chips, fmt.Sprintf("[black:#5FAFFF] %s [-:-:-]", t))
 	}
 	return strings.Join(chips, " ")
+}
+
+// getSSHKeyForServer attempts to fetch SSH key details for the server's identity file
+func (sd *ServerDetails) getSSHKeyForServer(server domain.Server) *domain.SSHKey {
+	if sd.gitService == nil || sd.serverRepo == nil {
+		return nil
+	}
+
+	// Get the first identity file if available
+	if len(server.IdentityFiles) == 0 {
+		return nil
+	}
+
+	identityFile := server.IdentityFiles[0]
+
+	// Expand ~ to home directory for comparison
+	if strings.HasPrefix(identityFile, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err == nil {
+			identityFile = filepath.Join(homeDir, identityFile[2:])
+		}
+	} else if identityFile == "~" {
+		homeDir, err := os.UserHomeDir()
+		if err == nil {
+			identityFile = homeDir
+		}
+	}
+
+	// Fetch all SSH keys and find the one matching this identity file
+	allKeys, err := sd.gitService.ListAllSSHKeys(sd.serverRepo)
+	if err != nil {
+		return nil
+	}
+
+	for _, key := range allKeys {
+		if key.Path == identityFile {
+			return &key
+		}
+	}
+
+	return nil
 }
 
 func (sd *ServerDetails) UpdateServer(server domain.Server) {
@@ -87,6 +135,42 @@ func (sd *ServerDetails) UpdateServer(server domain.Server) {
 		aliasText, hostText, userText, portText,
 		serverKey, tagsText, pinnedStr,
 		lastSeen, server.SSHCount)
+
+	// Add SSH Key Details section if key is configured
+	if sshKey := sd.getSSHKeyForServer(server); sshKey != nil {
+		text += "\n[::b]SSH Key Details:[-]\n"
+		text += fmt.Sprintf("  [dim]Path:[-] %s\n", sshKey.Path)
+		text += fmt.Sprintf("  [dim]Type:[-] %s\n", sshKey.Type)
+		if sshKey.Size > 0 {
+			text += fmt.Sprintf("  [dim]Size:[-] %d bits\n", sshKey.Size)
+		}
+		if sshKey.Comment != "" {
+			text += fmt.Sprintf("  [dim]Comment:[-] %s\n", sshKey.Comment)
+		}
+		text += "\n[::b]  Status:[-]\n"
+		if sshKey.LoadedInAgent {
+			text += "    [green]✓[-] Loaded in ssh-agent\n"
+		} else {
+			text += "    [dim]○[-] Not loaded in ssh-agent\n"
+		}
+		if sshKey.HasPublicKey {
+			text += "    [green]✓[-] Public key (.pub) exists\n"
+		} else {
+			text += "    [red]✗[-] Public key (.pub) missing\n"
+		}
+		if sshKey.IsEncrypted {
+			text += "    [yellow]🔒[-] Encrypted (passphrase protected)\n"
+		} else {
+			text += "    [dim]🔓[-] Not encrypted\n"
+		}
+		text += "\n[::b]  Commands:[-]\n"
+		if sshKey.LoadedInAgent {
+			text += "    [yellow]u[-]: Unload from ssh-agent\n"
+		} else {
+			text += "    [yellow]l[-]: Load into ssh-agent\n"
+		}
+		text += "    [yellow]C[-]: Edit comment\n"
+	}
 
 	// Advanced settings section (only show non-empty fields)
 	// Organized by logical grouping for better readability
@@ -213,7 +297,7 @@ func (sd *ServerDetails) UpdateServer(server domain.Server) {
 	}
 
 	// Commands list
-	text += "\n[::b]Commands:[-]\n  Enter: SSH connect\n  f: Port forward\n  x: Stop forwarding\n  c: Copy SSH command\n  g: Ping server\n  r: Refresh list\n  a: Add new server\n  e: Edit entry\n  t: Edit tags\n  d: Delete entry\n  p: Pin/Unpin"
+	text += "\n[::b]Commands:[-]\n  [yellow]Enter[-]: SSH connect\n  [yellow]f[-]: Port forward\n  [yellow]x[-]: Stop forwarding\n  [yellow]c[-]: Copy SSH command\n  [yellow]g[-]: Ping server\n  [yellow]r[-]: Refresh list\n  [yellow]a[-]: Add new server\n  [yellow]e[-]: Edit entry\n  [yellow]t[-]: Edit tags\n  [yellow]d[-]: Delete entry\n  [yellow]p[-]: Pin/Unpin"
 
 	sd.TextView.SetText(text)
 }

--- a/internal/adapters/ui/sshkey_details.go
+++ b/internal/adapters/ui/sshkey_details.go
@@ -1,0 +1,114 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Adembc/lazyssh/internal/core/domain"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type SSHKeyDetails struct {
+	*tview.TextView
+	currentKey *domain.SSHKey
+}
+
+func NewSSHKeyDetails() *SSHKeyDetails {
+	details := &SSHKeyDetails{
+		TextView: tview.NewTextView(),
+	}
+	details.build()
+	return details
+}
+
+func (kd *SSHKeyDetails) build() {
+	kd.TextView.SetDynamicColors(true).
+		SetWrap(true).
+		SetBorder(true).
+		SetTitle(" SSH Key Details ").
+		SetTitleAlign(tview.AlignCenter).
+		SetBorderColor(tcell.Color238).
+		SetTitleColor(tcell.Color250)
+}
+
+func (kd *SSHKeyDetails) UpdateKey(key domain.SSHKey) {
+	kd.currentKey = &key
+	var details strings.Builder
+
+	// Key name
+	details.WriteString(fmt.Sprintf("[yellow]%s[-]\n\n", key.Name))
+
+	// Basic info section
+	details.WriteString("[white::b]Basic Info:[-]\n")
+	details.WriteString(fmt.Sprintf("  [dim]Path:[-] %s\n", key.Path))
+	details.WriteString(fmt.Sprintf("  [dim]Type:[-] %s\n", key.Type))
+	if key.Size > 0 {
+		details.WriteString(fmt.Sprintf("  [dim]Size:[-] %d bits\n", key.Size))
+	}
+	if key.Comment != "" {
+		details.WriteString(fmt.Sprintf("  [dim]Comment:[-] %s\n", key.Comment))
+	}
+	if key.Fingerprint != "" {
+		details.WriteString(fmt.Sprintf("  [dim]Fingerprint:[-] %s\n", key.Fingerprint))
+	}
+	details.WriteString("\n")
+
+	// Status section
+	details.WriteString("[white::b]Status:[-]\n")
+	if key.LoadedInAgent {
+		details.WriteString("  [green]✓[-] Loaded in ssh-agent\n")
+	} else {
+		details.WriteString("  [dim]○[-] Not loaded in ssh-agent\n")
+	}
+	if key.HasPublicKey {
+		details.WriteString("  [green]✓[-] Public key (.pub) exists\n")
+	} else {
+		details.WriteString("  [red]✗[-] Public key (.pub) missing\n")
+	}
+	if key.IsEncrypted {
+		details.WriteString("  [yellow]🔒[-] Encrypted (passphrase protected)\n")
+	} else {
+		details.WriteString("  [dim]🔓[-] Not encrypted\n")
+	}
+	details.WriteString("\n")
+
+	// Commands section
+	details.WriteString("[white::b]Commands:[-]\n")
+	if key.LoadedInAgent {
+		details.WriteString("  [yellow]u[-]: Unload from ssh-agent\n")
+	} else {
+		details.WriteString("  [yellow]l[-]: Load into ssh-agent\n")
+	}
+	// Show comment edit command for keys with a known file path
+	// This includes both filesystem keys and agent keys that have been matched to their files
+	if key.Path != "" {
+		details.WriteString("  [yellow]C[-]: Edit comment\n")
+	}
+
+	kd.TextView.SetText(details.String())
+}
+
+func (kd *SSHKeyDetails) Clear() {
+	kd.TextView.SetText("")
+	kd.currentKey = nil
+}
+
+// GetCurrentKey returns the currently displayed key.
+func (kd *SSHKeyDetails) GetCurrentKey() *domain.SSHKey {
+	return kd.currentKey
+}

--- a/internal/adapters/ui/sshkeys_list.go
+++ b/internal/adapters/ui/sshkeys_list.go
@@ -1,0 +1,125 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"fmt"
+
+	"github.com/Adembc/lazyssh/internal/core/domain"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type SSHKeysList struct {
+	*tview.List
+	keys              []domain.SSHKey
+	onSelectionChange func(domain.SSHKey)
+}
+
+func NewSSHKeysList() *SSHKeysList {
+	list := &SSHKeysList{
+		List: tview.NewList(),
+	}
+	list.build()
+	return list
+}
+
+func (kl *SSHKeysList) build() {
+	kl.List.ShowSecondaryText(false)
+	kl.List.SetBorder(true).
+		SetTitle(" SSH Keys ").
+		SetTitleAlign(tview.AlignCenter).
+		SetBorderColor(tcell.Color238).
+		SetTitleColor(tcell.Color250)
+	kl.List.
+		SetSelectedBackgroundColor(tcell.Color24).
+		SetSelectedTextColor(tcell.Color255).
+		SetHighlightFullLine(true)
+
+	kl.List.SetChangedFunc(func(index int, mainText string, secondaryText string, shortcut rune) {
+		if index >= 0 && index < len(kl.keys) && kl.onSelectionChange != nil {
+			kl.onSelectionChange(kl.keys[index])
+		}
+	})
+}
+
+func (kl *SSHKeysList) UpdateKeys(keys []domain.SSHKey) {
+	kl.keys = keys
+	kl.List.Clear()
+
+	for i := range keys {
+		primary := formatSSHKeyLine(keys[i])
+		idx := i
+		kl.List.AddItem(primary, "", 0, func() {
+			// No selection action on Enter for keys
+			_ = idx
+		})
+	}
+
+	if kl.List.GetItemCount() > 0 {
+		kl.List.SetCurrentItem(0)
+		if kl.onSelectionChange != nil {
+			kl.onSelectionChange(kl.keys[0])
+		}
+	}
+}
+
+func (kl *SSHKeysList) GetSelectedKey() (domain.SSHKey, bool) {
+	idx := kl.List.GetCurrentItem()
+	if idx >= 0 && idx < len(kl.keys) {
+		return kl.keys[idx], true
+	}
+	return domain.SSHKey{}, false
+}
+
+func (kl *SSHKeysList) OnSelectionChange(fn func(key domain.SSHKey)) *SSHKeysList {
+	kl.onSelectionChange = fn
+	return kl
+}
+
+func (kl *SSHKeysList) GetCurrentItem() int {
+	return kl.List.GetCurrentItem()
+}
+
+func (kl *SSHKeysList) GetItemCount() int {
+	return kl.List.GetItemCount()
+}
+
+func (kl *SSHKeysList) SetCurrentItem(index int) {
+	kl.List.SetCurrentItem(index)
+}
+
+func formatSSHKeyLine(key domain.SSHKey) string {
+	// Format: "[indicator] name (type:size)"
+	indicator := " "
+	if key.LoadedInAgent {
+		indicator = "[green]●[-]" // Green dot for loaded keys
+	}
+
+	typeInfo := key.Type
+	if key.Size > 0 {
+		typeInfo = fmt.Sprintf("%s:%d", key.Type, key.Size)
+	}
+
+	flags := ""
+	if key.IsEncrypted {
+		flags += "[yellow]🔒[-] "
+	}
+	if !key.HasPublicKey {
+		flags += "[red]⛅[-] "
+	}
+
+	return fmt.Sprintf("%s %s%s [dim](%s)[-]", indicator, flags, key.Name, typeInfo)
+}

--- a/internal/adapters/ui/status_bar.go
+++ b/internal/adapters/ui/status_bar.go
@@ -20,7 +20,7 @@ import (
 )
 
 func DefaultStatusText() string {
-	return "[white]↑↓[-] Navigate  • [white]Enter[-] SSH  • [white]f[-] Forward  • [white]x[-] Stop Forward  • [white]c[-] Copy SSH  • [white]a[-] Add  • [white]e[-] Edit  • [white]g[-] Ping  • [white]d[-] Delete  • [white]p[-] Pin/Unpin  • [white]/[-] Search  • [white]q[-] Quit"
+	return "[white]↑↓[-] Navigate  • [white]Tab[-] Switch Panel  • [white]Enter[-] SSH  • [white]l/u[-] Load/Unload Key  • [white]C[-] Edit Comment  • [white]f[-] Forward  • [white]x[-] Stop Forward  • [white]c[-] Copy SSH  • [white]a[-] Add  • [white]e[-] Edit  • [white]g[-] Ping  • [white]G[-] Git SSH  • [white]d[-] Delete  • [white]p[-] Pin/Unpin  • [white]/[-] Search  • [white]q[-] Quit"
 }
 
 func NewStatusBar() *tview.TextView {

--- a/internal/adapters/ui/tui.go
+++ b/internal/adapters/ui/tui.go
@@ -15,6 +15,9 @@
 package ui
 
 import (
+	"fmt"
+	"sync"
+
 	"github.com/gdamore/tcell/v2"
 	"go.uber.org/zap"
 
@@ -34,25 +37,37 @@ type tui struct {
 
 	app           *tview.Application
 	serverService ports.ServerService
+	serverRepo    ports.ServerRepository
+	gitService    ports.GitService
 
-	header     *AppHeader
-	searchBar  *SearchBar
-	serverList *ServerList
-	details    *ServerDetails
-	statusBar  *tview.TextView
+	header           *AppHeader
+	searchBar        *SearchBar
+	serverList       *ServerList
+	sshAgentKeysList *SSHKeysList // SSH keys from ssh-agent
+	serverDetails    *ServerDetails
+	sshKeyDetails    *SSHKeyDetails
+	gitInfo          *GitInfo
+	statusBar        *tview.TextView
 
 	root    *tview.Flex
 	left    *tview.Flex
 	content *tview.Flex
 
-	sortMode SortMode
+	sortMode     SortMode
+	currentPanel int // 0=Servers, 1=SSH Agent
+
+	// Error storage for printing at exit
+	errors      []string
+	errorsMutex sync.Mutex
 }
 
-func NewTUI(logger *zap.SugaredLogger, ss ports.ServerService, version, commit string) App {
+func NewTUI(logger *zap.SugaredLogger, ss ports.ServerService, sr ports.ServerRepository, gs ports.GitService, version, commit string) App {
 	return &tui{
 		logger:        logger,
 		app:           tview.NewApplication(),
 		serverService: ss,
+		serverRepo:    sr,
+		gitService:    gs,
 		version:       version,
 		commit:        commit,
 	}
@@ -63,6 +78,8 @@ func (t *tui) Run() error {
 		if r := recover(); r != nil {
 			t.logger.Errorw("panic recovered", "error", r)
 		}
+		// Print any stored errors at exit for debugging
+		t.printErrorsOnExit()
 	}()
 	t.app.EnableMouse(true)
 	t.initializeTheme().buildComponents().buildLayout().bindEvents().loadInitialData()
@@ -98,7 +115,27 @@ func (t *tui) buildComponents() *tui {
 	t.serverList = NewServerList().
 		OnSelectionChange(t.handleServerSelectionChange).
 		OnReturnToSearch(t.handleReturnToSearch)
-	t.details = NewServerDetails()
+
+	t.sshAgentKeysList = NewSSHKeysList().
+		OnSelectionChange(t.handleSSHKeySelectionChange)
+	t.sshAgentKeysList.SetTitle(" SSH Agent ")
+
+	// Add mouse handlers for panel selection
+	t.serverList.SetMouseCapture(func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+		if action == tview.MouseLeftClick {
+			t.handlePanelClick(0) // 0 = Servers panel
+		}
+		return action, event
+	})
+	t.sshAgentKeysList.SetMouseCapture(func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+		if action == tview.MouseLeftClick {
+			t.handlePanelClick(1) // 1 = SSH Agent panel
+		}
+		return action, event
+	})
+	t.serverDetails = NewServerDetails(t.gitService, t.serverRepo)
+	t.sshKeyDetails = NewSSHKeyDetails()
+	t.gitInfo = NewGitInfo(t.gitService)
 	t.statusBar = NewStatusBar()
 
 	// default sort mode
@@ -108,12 +145,15 @@ func (t *tui) buildComponents() *tui {
 }
 
 func (t *tui) buildLayout() *tui {
-	t.left = tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(t.searchBar, 3, 0, false).
-		AddItem(t.serverList, 0, 1, true)
+	t.updateLeftPanel()
 
-	right := tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(t.details, 0, 1, false)
+	// Right panel shows details based on focus
+	right := tview.NewFlex().SetDirection(tview.FlexRow)
+	if t.currentPanel != 0 {
+		right.AddItem(t.sshKeyDetails, 0, 1, false)
+	} else {
+		right.AddItem(t.serverDetails, 0, 1, false)
+	}
 
 	t.content = tview.NewFlex().SetDirection(tview.FlexColumn).
 		AddItem(t.left, 0, 3, true).
@@ -124,6 +164,25 @@ func (t *tui) buildLayout() *tui {
 		AddItem(t.content, 0, 1, true).
 		AddItem(t.statusBar, 1, 0, false)
 	return t
+}
+
+func (t *tui) updateLeftPanel() {
+	t.gitInfo.Update()
+
+	// Rebuild left panel: SearchBar, Servers, SSH Agent, Git Info
+	t.left = tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(t.searchBar, 3, 0, false).
+		AddItem(t.serverList, 0, 1, true).
+		AddItem(t.sshAgentKeysList, 0, 1, false)
+
+	if t.gitInfo.IsVisible() {
+		t.left.AddItem(t.gitInfo, 4, 0, false)
+	}
+}
+
+func (t *tui) updateGitInfoPanel() {
+	// Alias for updateLeftPanel to maintain compatibility
+	t.updateLeftPanel()
 }
 
 func (t *tui) bindEvents() *tui {
@@ -137,11 +196,98 @@ func (t *tui) loadInitialData() *tui {
 	t.updateListTitle()
 	t.serverList.UpdateServers(servers)
 
+	// Load SSH keys from ssh-agent
+	if t.gitService != nil {
+		agentKeys, err := t.gitService.ListSSHKeysFromAgent()
+		if err == nil {
+			t.sshAgentKeysList.UpdateKeys(agentKeys)
+		}
+	}
+
+	// Set initial border colors (Servers panel is focused by default)
+	t.updatePanelBorders()
+
 	return t
 }
 
 func (t *tui) updateListTitle() {
 	if t.serverList != nil {
 		t.serverList.SetTitle(" Servers — Sort: " + t.sortMode.String() + " ")
+	}
+}
+
+func (t *tui) updatePanelBorders() {
+	// Update border colors to show which panel is active
+	dimColor := tcell.Color238
+	activeColor := tcell.ColorBlue
+
+	// Selected background colors
+	dimSelectionColor := tcell.Color238   // Gray for unfocused panel
+	activeSelectionColor := tcell.Color24 // Blue for focused panel
+
+	// Reset all borders and selections to dim
+	t.serverList.SetBorderColor(dimColor)
+	t.sshAgentKeysList.SetBorderColor(dimColor)
+	t.serverList.SetSelectedBackgroundColor(dimSelectionColor)
+	t.sshAgentKeysList.SetSelectedBackgroundColor(dimSelectionColor)
+
+	// Highlight the active panel
+	switch t.currentPanel {
+	case 0:
+		t.serverList.SetBorderColor(activeColor)
+		t.serverList.SetSelectedBackgroundColor(activeSelectionColor)
+	case 1:
+		t.sshAgentKeysList.SetBorderColor(activeColor)
+		t.sshAgentKeysList.SetSelectedBackgroundColor(activeSelectionColor)
+	}
+}
+
+func (t *tui) updateRightPanel() {
+	// Rebuild the right panel to show appropriate details
+	if t.content == nil {
+		return
+	}
+
+	right := tview.NewFlex().SetDirection(tview.FlexRow)
+	if t.currentPanel == 0 {
+		// Servers panel - show server details
+		right.AddItem(t.serverDetails, 0, 1, false)
+	} else {
+		// SSH Keys or SSH Agent panel - show key details
+		right.AddItem(t.sshKeyDetails, 0, 1, false)
+	}
+
+	// Rebuild content with updated right panel
+	t.content.Clear()
+	t.content.AddItem(t.left, 0, 3, true)
+	t.content.AddItem(right, 0, 2, false)
+}
+
+// storeErrorf stores an error for later printing on exit.
+// Keeps only the last 10 errors in memory.
+func (t *tui) storeErrorf(format string, args ...interface{}) {
+	t.errorsMutex.Lock()
+	defer t.errorsMutex.Unlock()
+	msg := fmt.Sprintf(format, args...)
+	t.errors = append(t.errors, msg)
+	// Keep only the last 10 errors
+	if len(t.errors) > 10 {
+		t.errors = t.errors[len(t.errors)-10:]
+	}
+}
+
+// printErrorsOnExit prints any stored errors to stdout when the app exits.
+func (t *tui) printErrorsOnExit() {
+	t.errorsMutex.Lock()
+	errors := make([]string, len(t.errors))
+	copy(errors, t.errors)
+	t.errorsMutex.Unlock()
+
+	if len(errors) > 0 {
+		fmt.Println("\n=== Errors during session ===")
+		for _, err := range errors {
+			fmt.Println(err)
+		}
+		fmt.Println("==============================")
 	}
 }

--- a/internal/core/domain/sshkey.go
+++ b/internal/core/domain/sshkey.go
@@ -1,0 +1,57 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import "time"
+
+// SSHKey represents an SSH key that can be used for authentication.
+type SSHKey struct {
+	// Path is the absolute path to the private key file
+	Path string
+
+	// Name is the display name (typically filename without path)
+	Name string
+
+	// Comment is the key comment (from public key or ssh-add)
+	Comment string
+
+	// Type is the key algorithm (rsa, ed25519, ecdsa, etc.)
+	Type string
+
+	// Size is the key size in bits (e.g., 4096 for RSA)
+	Size int
+
+	// Fingerprint is the key fingerprint (e.g., "SHA256:5NUhY...")
+	Fingerprint string
+
+	// LoadedInAgent indicates if the key is currently loaded in ssh-agent
+	LoadedInAgent bool
+
+	// IsEncrypted indicates if the private key is encrypted with a passphrase
+	IsEncrypted bool
+
+	// HasPublicKey indicates if a corresponding .pub file exists
+	HasPublicKey bool
+
+	// ModTime is the last modification time of the private key file
+	ModTime time.Time
+
+	// Source indicates where this key was discovered ("config" or "agent")
+	Source string
+
+	// PublicKeyLine is the full public key line from ssh-add -L output.
+	// Used for unloading keys from ssh-agent. Format: "ssh-rsa AAAAB3... comment"
+	PublicKeyLine string
+}

--- a/internal/core/ports/services.go
+++ b/internal/core/ports/services.go
@@ -33,3 +33,34 @@ type ServerService interface {
 	IsForwarding(alias string) bool
 	Ping(server domain.Server) (bool, time.Duration, error)
 }
+
+type SSHKey struct {
+	Name        string
+	Path        string
+	HasPubKey   bool
+	ModTime     time.Time
+	IsEncrypted bool
+	InAgent     bool // Whether the key is loaded in ssh-agent/keychain
+}
+
+type GitService interface {
+	IsGitRepository(path string) bool
+	GetGitRootPath(path string) (string, error)
+	GetPushRemoteURL(repoPath string) (remoteName, remoteURL string, err error)
+	ListSSHKeys(sshDir string, serverRepo ServerRepository) ([]SSHKey, error)
+	ConfigureGitSSHKey(repoPath string, keyPath string, scope string) error
+	GetCurrentGitSSHConfig(repoPath string) (string, error)
+	ClearGitSSHConfig(repoPath string, scope string) error
+	GetLoadedAgentKeys() ([]string, error)
+
+	// SSH Key management
+	ListAllSSHKeys(serverRepo ServerRepository) ([]domain.SSHKey, error)
+	ListSSHKeysFromConfig(serverRepo ServerRepository) ([]domain.SSHKey, error)
+	ListSSHKeysFromAgent() ([]domain.SSHKey, error)
+	LoadKeyToAgent(keyPath string) error
+	UnloadKeyFromAgent(publicKeyLine string) error
+	UpdateKeyComment(keyPath, comment string) error
+
+	// SetServerRepository sets the server repository for SSH key path resolution
+	SetServerRepository(repo ServerRepository)
+}

--- a/internal/core/services/git_service.go
+++ b/internal/core/services/git_service.go
@@ -1,0 +1,1153 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Adembc/lazyssh/internal/core/domain"
+	"github.com/Adembc/lazyssh/internal/core/ports"
+	"go.uber.org/zap"
+)
+
+const (
+	// ScopeLocal represents repository-level git configuration.
+	ScopeLocal = "local"
+	// ScopeGlobal represents user-level git configuration.
+	ScopeGlobal = "global"
+	// ScopeBoth represents both repository and user-level git configuration.
+	ScopeBoth = "both"
+
+	// SSH key type constants
+	keyTypeRSA     = "rsa"
+	keyTypeEd25519 = "ed25519"
+	keyTypeECDSA   = "ecdsa"
+	keyTypeDSA     = "dsa"
+
+	// SSH file constants
+	fileKnownHosts     = "known_hosts"
+	fileConfig         = "config"
+	fileAuthorizedKeys = "authorized_keys"
+)
+
+type gitService struct {
+	logger           *zap.SugaredLogger
+	serverRepository ports.ServerRepository
+}
+
+// NewGitService creates a new instance of gitService.
+func NewGitService(logger *zap.SugaredLogger) ports.GitService {
+	return &gitService{
+		logger: logger,
+	}
+}
+
+// SetServerRepository sets the server repository for the git service.
+// This is needed to resolve SSH key paths from SSH config.
+func (gs *gitService) SetServerRepository(repo ports.ServerRepository) {
+	gs.serverRepository = repo
+}
+
+// IsGitRepository checks if the given path is inside a git repository.
+func (gs *gitService) IsGitRepository(path string) bool {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--git-dir")
+	err := cmd.Run()
+	return err == nil
+}
+
+// GetGitRootPath returns the root path of the git repository.
+func (gs *gitService) GetGitRootPath(path string) (string, error) {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("not a git repository or git command failed: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// GetPushRemoteURL returns the push remote name and URL for the git repository.
+// It searches for remotes with push URLs, preferring "origin" if available.
+func (gs *gitService) GetPushRemoteURL(repoPath string) (remoteName, remoteURL string, err error) {
+	// First try to get origin push URL
+	cmd := exec.Command("git", "-C", repoPath, "remote", "-v")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get git remotes: %w", err)
+	}
+
+	// Parse git remote -v output
+	// Format: "origin    git@github.com:user/repo.git (fetch)"
+	//         "origin    git@github.com:user/repo.git (push)"
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+
+	var otherRemoteName, otherPushURL string
+
+	for _, line := range lines {
+		parts := strings.Fields(line)
+		if len(parts) < 3 {
+			continue
+		}
+		name := parts[0]
+		url := parts[1]
+		operation := strings.TrimPrefix(strings.TrimSuffix(parts[2], ")"), "(")
+
+		if operation == "push" {
+			if name == "origin" {
+				remoteName = name
+				remoteURL = url
+				return remoteName, remoteURL, nil
+			} else if otherRemoteName == "" {
+				otherRemoteName = name
+				otherPushURL = url
+			}
+		}
+	}
+
+	// Prefer origin, otherwise use the first available push remote
+	if otherRemoteName != "" {
+		return otherRemoteName, otherPushURL, nil
+	}
+
+	return "", "", fmt.Errorf("no push remote found")
+}
+
+// ListSSHKeys lists all SSH private keys from the SSH config and the specified SSH directory.
+func (gs *gitService) ListSSHKeys(sshDir string, serverRepo ports.ServerRepository) ([]ports.SSHKey, error) {
+	keyMap := make(map[string]*ports.SSHKey)
+
+	// First, get keys from SSH config (this is the primary source)
+	gs.addKeysFromSSHConfig(serverRepo, keyMap)
+
+	// Also scan ~/.ssh/ directory for additional keys
+	if sshDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		sshDir = filepath.Join(homeDir, ".ssh")
+	}
+
+	if err := gs.addKeysFromDirectory(sshDir, keyMap); err != nil && len(keyMap) == 0 {
+		return nil, err
+	}
+
+	// Check which keys are loaded in ssh-agent/keychain
+	gs.markKeysInAgent(keyMap)
+
+	return gs.keysMapToSlice(keyMap), nil
+}
+
+func (gs *gitService) addKeysFromSSHConfig(serverRepo ports.ServerRepository, keyMap map[string]*ports.SSHKey) {
+	if serverRepo == nil {
+		return
+	}
+
+	servers, err := serverRepo.ListServers("")
+	if err != nil {
+		return
+	}
+
+	for _, server := range servers {
+		for _, identityFile := range server.IdentityFiles {
+			gs.addKeyFromPath(identityFile, keyMap)
+		}
+	}
+}
+
+func (gs *gitService) addKeyFromPath(identityFile string, keyMap map[string]*ports.SSHKey) {
+	if identityFile == "" {
+		return
+	}
+
+	// Expand ~ to home directory
+	if strings.HasPrefix(identityFile, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err == nil {
+			identityFile = filepath.Join(homeDir, identityFile[2:])
+		}
+	}
+
+	// Check if key already exists in map
+	if _, exists := keyMap[identityFile]; exists {
+		return
+	}
+
+	// Check if file exists
+	info, err := os.Stat(identityFile)
+	if err != nil {
+		gs.logger.Debugf("Identity file not found: %s", identityFile)
+		return
+	}
+
+	isPrivateKey, isEncrypted := gs.isSSHPrivateKey(identityFile)
+	if !isPrivateKey {
+		return
+	}
+
+	key := &ports.SSHKey{
+		Name:        filepath.Base(identityFile),
+		Path:        identityFile,
+		HasPubKey:   false,
+		ModTime:     info.ModTime(),
+		IsEncrypted: isEncrypted,
+	}
+
+	// Check for corresponding public key
+	pubKeyPath := identityFile + ".pub"
+	if _, err := os.Stat(pubKeyPath); err == nil {
+		key.HasPubKey = true
+	}
+
+	keyMap[identityFile] = key
+}
+
+func (gs *gitService) addKeysFromDirectory(sshDir string, keyMap map[string]*ports.SSHKey) error {
+	entries, err := os.ReadDir(sshDir)
+	if err != nil {
+		if len(keyMap) > 0 {
+			gs.logger.Debugf("Could not read SSH directory %s: %v", sshDir, err)
+			return nil
+		}
+		return fmt.Errorf("failed to read SSH directory: %w", err)
+	}
+
+	// Process files from directory
+	for _, entry := range entries {
+		if entry.IsDir() || gs.shouldSkipFile(entry.Name()) {
+			continue
+		}
+
+		keyPath := filepath.Join(sshDir, entry.Name())
+		if _, exists := keyMap[keyPath]; exists {
+			continue
+		}
+
+		gs.addKeyFromDirectoryEntry(entry, sshDir, keyMap)
+	}
+
+	// Check for corresponding public keys
+	gs.markPublicKeys(entries, sshDir, keyMap)
+	return nil
+}
+
+func (gs *gitService) shouldSkipFile(name string) bool {
+	return name == fileKnownHosts || name == fileConfig || name == fileAuthorizedKeys ||
+		strings.HasSuffix(name, ".pub") || strings.HasPrefix(name, ".")
+}
+
+func (gs *gitService) addKeyFromDirectoryEntry(entry os.DirEntry, sshDir string, keyMap map[string]*ports.SSHKey) {
+	keyPath := filepath.Join(sshDir, entry.Name())
+
+	info, err := entry.Info()
+	if err != nil {
+		gs.logger.Warnf("Failed to get info for %s: %v", keyPath, err)
+		return
+	}
+
+	isPrivateKey, isEncrypted := gs.isSSHPrivateKey(keyPath)
+	if !isPrivateKey {
+		return
+	}
+
+	key := &ports.SSHKey{
+		Name:        entry.Name(),
+		Path:        keyPath,
+		HasPubKey:   false,
+		ModTime:     info.ModTime(),
+		IsEncrypted: isEncrypted,
+	}
+
+	keyMap[keyPath] = key
+}
+
+func (gs *gitService) markPublicKeys(entries []os.DirEntry, sshDir string, keyMap map[string]*ports.SSHKey) {
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".pub") {
+			baseName := strings.TrimSuffix(entry.Name(), ".pub")
+			baseKeyPath := filepath.Join(sshDir, baseName)
+			if key, exists := keyMap[baseKeyPath]; exists {
+				key.HasPubKey = true
+			}
+		}
+	}
+}
+
+func (gs *gitService) markKeysInAgent(keyMap map[string]*ports.SSHKey) {
+	// Get list of keys loaded in ssh-agent
+	agentKeys, err := gs.GetLoadedAgentKeys()
+	if err != nil {
+		gs.logger.Debugf("Could not check ssh-agent keys: %v", err)
+		return
+	}
+
+	if len(agentKeys) == 0 {
+		return
+	}
+
+	// For each key in our map, check if it's in the agent
+	for keyPath, key := range keyMap {
+		// Check if any agent key line contains this key path
+		for _, agentLine := range agentKeys {
+			if strings.Contains(agentLine, keyPath) || strings.Contains(agentLine, key.Name) {
+				key.InAgent = true
+				break
+			}
+		}
+	}
+}
+
+func (gs *gitService) keysMapToSlice(keyMap map[string]*ports.SSHKey) []ports.SSHKey {
+	keys := make([]ports.SSHKey, 0, len(keyMap))
+	for _, key := range keyMap {
+		keys = append(keys, *key)
+	}
+
+	// Sort by: 1) keys in agent first, 2) then by modification time (newest first)
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].InAgent != keys[j].InAgent {
+			return keys[i].InAgent // Keys in agent come first
+		}
+		return keys[i].ModTime.After(keys[j].ModTime)
+	})
+
+	return keys
+}
+
+// isSSHPrivateKey checks if a file is an SSH private key and if it's encrypted.
+func (gs *gitService) isSSHPrivateKey(path string) (bool, bool) {
+	//nolint:gosec // Reading SSH keys from user's .ssh directory is intentional
+	file, err := os.Open(path)
+	if err != nil {
+		return false, false
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			gs.logger.Warnf("Failed to close file %s: %v", path, closeErr)
+		}
+	}()
+
+	scanner := bufio.NewScanner(file)
+	isPrivateKey := false
+	isEncrypted := false
+
+	// Read first few lines
+	lineCount := 0
+	for scanner.Scan() && lineCount < 10 {
+		line := scanner.Text()
+		lineCount++
+
+		if strings.Contains(line, "BEGIN") && strings.Contains(line, "PRIVATE KEY") {
+			isPrivateKey = true
+		}
+
+		if strings.Contains(line, "ENCRYPTED") {
+			isEncrypted = true
+		}
+
+		// Old OpenSSH format check
+		if strings.Contains(line, "Proc-Type: 4,ENCRYPTED") {
+			isEncrypted = true
+		}
+	}
+
+	return isPrivateKey, isEncrypted
+}
+
+// ConfigureGitSSHKey configures Git to use the specified SSH key.
+// scope can be "local" (repository-level) or "global" (user-level).
+func (gs *gitService) ConfigureGitSSHKey(repoPath string, keyPath string, scope string) error {
+	if scope != ScopeLocal && scope != ScopeGlobal {
+		return fmt.Errorf("invalid scope: %s (must be 'local' or 'global')", scope)
+	}
+
+	// Verify the key file exists
+	if _, err := os.Stat(keyPath); err != nil {
+		return fmt.Errorf("SSH key not found at %s: %w", keyPath, err)
+	}
+
+	// Build the SSH command
+	sshCommand := fmt.Sprintf("ssh -i %s -o IdentitiesOnly=yes", keyPath)
+
+	var cmd *exec.Cmd
+	if scope == ScopeLocal {
+		// Repository-level configuration
+		//nolint:gosec // git command with controlled arguments is safe
+		cmd = exec.Command("git", "-C", repoPath, "config", "--local", "core.sshCommand", sshCommand)
+	} else {
+		// Global configuration
+		//nolint:gosec // git command with controlled arguments is safe
+		cmd = exec.Command("git", "config", "--global", "core.sshCommand", sshCommand)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to configure Git SSH key: %w\nOutput: %s", err, string(output))
+	}
+
+	gs.logger.Infof("Successfully configured Git to use SSH key: %s (scope: %s)", keyPath, scope)
+	return nil
+}
+
+// GetCurrentGitSSHConfig retrieves the current Git SSH configuration.
+func (gs *gitService) GetCurrentGitSSHConfig(repoPath string) (string, error) {
+	// Try local config first
+	cmd := exec.Command("git", "-C", repoPath, "config", "--local", "core.sshCommand")
+	output, err := cmd.Output()
+	if err == nil && len(output) > 0 {
+		return strings.TrimSpace(string(output)), nil
+	}
+
+	// Try global config
+	cmd = exec.Command("git", "config", "--global", "core.sshCommand")
+	output, err = cmd.Output()
+	if err == nil && len(output) > 0 {
+		return strings.TrimSpace(string(output)), nil
+	}
+
+	// Try GIT_SSH_COMMAND environment variable
+	envSSH := os.Getenv("GIT_SSH_COMMAND")
+	if envSSH != "" {
+		return envSSH + " (from environment)", nil
+	}
+
+	return "", nil
+}
+
+// ClearGitSSHConfig removes the Git SSH configuration, resetting to default behavior.
+// scope can be "local" (repository-level), "global" (user-level), or "both".
+func (gs *gitService) ClearGitSSHConfig(repoPath string, scope string) error {
+	if scope != ScopeLocal && scope != ScopeGlobal && scope != ScopeBoth {
+		return fmt.Errorf("invalid scope: %s (must be 'local', 'global', or 'both')", scope)
+	}
+
+	var errs []string
+
+	// Clear local configuration
+	if scope == ScopeLocal || scope == ScopeBoth {
+		cmd := exec.Command("git", "-C", repoPath, "config", "--local", "--unset", "core.sshCommand")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			// Exit code 5 means key not found, which is not an error for unset
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 5 {
+				errs = append(errs, fmt.Sprintf("local: %v (output: %s)", err, string(output)))
+			}
+		} else {
+			gs.logger.Infof("Cleared local Git SSH configuration for %s", repoPath)
+		}
+	}
+
+	// Clear global configuration
+	if scope == ScopeGlobal || scope == ScopeBoth {
+		cmd := exec.Command("git", "config", "--global", "--unset", "core.sshCommand")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			// Exit code 5 means key not found, which is not an error for unset
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 5 {
+				errs = append(errs, fmt.Sprintf("global: %v (output: %s)", err, string(output)))
+			}
+		} else {
+			gs.logger.Infof("Cleared global Git SSH configuration")
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to clear Git SSH config: %s", strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// GetLoadedAgentKeys returns a list of SSH key fingerprints currently loaded in ssh-agent/keychain.
+func (gs *gitService) GetLoadedAgentKeys() ([]string, error) {
+	cmd := exec.Command("ssh-add", "-l")
+	output, err := cmd.Output()
+	if err != nil {
+		// Exit code 1 means no keys loaded, which is not an error
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to list ssh-agent keys: %w", err)
+	}
+
+	var fingerprints []string
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		// Format: "4096 SHA256:... comment (RSA)"
+		// We want to extract the file path if available, or the comment
+		parts := strings.Fields(line)
+		if len(parts) >= 3 {
+			// The fingerprint is in parts[1], but we also want to capture the full line
+			// to match against key paths later
+			fingerprints = append(fingerprints, line)
+		}
+	}
+
+	return fingerprints, nil
+}
+
+// ListAllSSHKeys returns all SSH keys from config identity files and ssh-agent.
+func (gs *gitService) ListAllSSHKeys(serverRepo ports.ServerRepository) ([]domain.SSHKey, error) {
+	keysMap := make(map[string]*domain.SSHKey)
+
+	// Get keys from ssh-agent first to know which are loaded
+	agentKeys := make(map[string]agentKeyInfo)
+	cmd := exec.Command("ssh-add", "-l")
+	if output, err := cmd.Output(); err == nil {
+		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+		for _, line := range lines {
+			if line == "" {
+				continue
+			}
+			// Parse: "4096 SHA256:5NUhY... comment (RSA)"
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				info := agentKeyInfo{
+					fingerprint: parts[1],
+					comment:     "",
+				}
+				if len(parts) >= 3 {
+					endIdx := len(parts) - 1
+					switch {
+					case strings.HasSuffix(line, "(RSA)"):
+						endIdx = len(parts) - 1
+					case strings.HasSuffix(line, "(ED25519)"):
+						endIdx = len(parts) - 1
+					case strings.HasSuffix(line, "(ECDSA)"):
+						endIdx = len(parts) - 1
+					}
+					info.comment = strings.Join(parts[2:endIdx], " ")
+				}
+				// Use fingerprint as key since we may not have path yet
+				agentKeys[parts[1]] = info
+			}
+		}
+	}
+
+	// Get identity files from SSH config
+	servers, _ := serverRepo.ListServers("")
+	for _, server := range servers {
+		for _, identityFile := range server.IdentityFiles {
+			expandedPath := identityFile
+			if strings.HasPrefix(identityFile, "~/") {
+				home, _ := os.UserHomeDir()
+				expandedPath = filepath.Join(home, identityFile[2:])
+			}
+
+			if _, exists := keysMap[expandedPath]; !exists {
+				if key := gs.parseKeyFile(expandedPath, agentKeys); key != nil {
+					keysMap[expandedPath] = key
+				}
+			}
+		}
+	}
+
+	// Also scan ~/.ssh/ directory
+	home, err := os.UserHomeDir()
+	if err == nil {
+		sshDir := filepath.Join(home, ".ssh")
+		if entries, err := os.ReadDir(sshDir); err == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+				name := entry.Name()
+				// Skip public keys, known_hosts, config, etc.
+				if strings.HasSuffix(name, ".pub") || name == fileKnownHosts ||
+					name == fileConfig || name == fileAuthorizedKeys {
+					continue
+				}
+
+				fullPath := filepath.Join(sshDir, name)
+				if _, exists := keysMap[fullPath]; !exists {
+					if key := gs.parseKeyFile(fullPath, agentKeys); key != nil {
+						keysMap[fullPath] = key
+					}
+				}
+			}
+		}
+	}
+
+	// Convert map to slice
+	keys := make([]domain.SSHKey, 0, len(keysMap))
+	for _, key := range keysMap {
+		keys = append(keys, *key)
+	}
+
+	// Sort: loaded keys first, then by name
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].LoadedInAgent != keys[j].LoadedInAgent {
+			return keys[i].LoadedInAgent
+		}
+		return keys[i].Name < keys[j].Name
+	})
+
+	return keys, nil
+}
+
+type agentKeyInfo struct {
+	fingerprint string
+	comment     string
+}
+
+func (gs *gitService) parseKeyFile(path string, agentKeys map[string]agentKeyInfo) *domain.SSHKey {
+	// Check if file exists and is readable
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil
+	}
+
+	// Read first few bytes to detect key type
+	// #nosec G304 -- path is validated from SSH config or ~/.ssh directory
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	// Must start with proper SSH key header
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "PRIVATE KEY") {
+		return nil
+	}
+
+	key := &domain.SSHKey{
+		Path:          path,
+		Name:          filepath.Base(path),
+		ModTime:       info.ModTime(),
+		Source:        "config",
+		LoadedInAgent: false,
+	}
+
+	// Detect key type and encryption
+	switch {
+	case strings.Contains(contentStr, "RSA PRIVATE KEY"):
+		key.Type = keyTypeRSA
+		key.IsEncrypted = strings.Contains(contentStr, "ENCRYPTED")
+	case strings.Contains(contentStr, "OPENSSH PRIVATE KEY"):
+		// Modern format - could be RSA, Ed25519, ECDSA
+		lowerName := strings.ToLower(key.Name)
+		switch {
+		case strings.Contains(path, "ed25519") || strings.Contains(lowerName, "ed25519"):
+			key.Type = keyTypeEd25519
+		case strings.Contains(path, "ecdsa") || strings.Contains(lowerName, "ecdsa"):
+			key.Type = keyTypeECDSA
+		default:
+			key.Type = keyTypeRSA // Default assumption
+		}
+		// Check for encryption by looking for bcrypt cipher indicator
+		// Modern OpenSSH keys use "bcrypt" for encryption (base64: YmNyeXB0)
+		// Old PEM format uses "Proc-Type: 4,ENCRYPTED"
+		key.IsEncrypted = strings.Contains(contentStr, "Proc-Type: 4,ENCRYPTED") ||
+			strings.Contains(contentStr, "YmNyeXB0") // bcrypt cipher indicator
+	case strings.Contains(contentStr, "DSA PRIVATE KEY"):
+		key.Type = keyTypeDSA
+		key.IsEncrypted = strings.Contains(contentStr, "ENCRYPTED")
+	case strings.Contains(contentStr, "EC PRIVATE KEY"):
+		key.Type = keyTypeECDSA
+		key.IsEncrypted = strings.Contains(contentStr, "ENCRYPTED")
+	default:
+		return nil // Unknown key type
+	}
+
+	// Check for public key
+	pubPath := path + ".pub"
+	if _, err := os.Stat(pubPath); err == nil {
+		key.HasPublicKey = true
+
+		// Read public key for comment and fingerprint
+		// #nosec G304 -- pubPath is derived from validated private key path
+		if pubContent, err := os.ReadFile(pubPath); err == nil {
+			pubKeyLine := strings.TrimSpace(string(pubContent))
+			parts := strings.Fields(pubKeyLine)
+			if len(parts) >= 3 {
+				key.Comment = strings.Join(parts[2:], " ")
+			}
+			// Store the full public key line for unloading (same format as ssh-add -L output)
+			key.PublicKeyLine = pubKeyLine
+		}
+
+		// Get fingerprint using ssh-keygen
+		// #nosec G204 -- pubPath is derived from validated private key path
+		cmd := exec.Command("ssh-keygen", "-lf", pubPath)
+		if output, err := cmd.Output(); err == nil {
+			parts := strings.Fields(string(output))
+			if len(parts) >= 2 {
+				key.Size, _ = strconv.Atoi(parts[0])
+				key.Fingerprint = parts[1]
+
+				// Check if this key is loaded in agent
+				for fp, info := range agentKeys {
+					if fp == key.Fingerprint || info.comment == key.Comment {
+						key.LoadedInAgent = true
+						if key.Comment == "" {
+							key.Comment = info.comment
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return key
+}
+
+// ListSSHKeysFromConfig returns SSH keys from config files (IdentityFile entries) and ~/.ssh directory.
+func (gs *gitService) ListSSHKeysFromConfig(serverRepo ports.ServerRepository) ([]domain.SSHKey, error) {
+	keysMap := make(map[string]*domain.SSHKey)
+
+	// Get keys from ssh-agent to mark which ones are loaded
+	agentKeys := make(map[string]agentKeyInfo)
+	cmd := exec.Command("ssh-add", "-l")
+	if output, err := cmd.Output(); err == nil {
+		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+		for _, line := range lines {
+			if line == "" {
+				continue
+			}
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				info := agentKeyInfo{
+					fingerprint: parts[1],
+					comment:     "",
+				}
+				if len(parts) >= 3 {
+					endIdx := len(parts) - 1
+					switch {
+					case strings.HasSuffix(line, "(RSA)"):
+						endIdx = len(parts) - 1
+					case strings.HasSuffix(line, "(ED25519)"):
+						endIdx = len(parts) - 1
+					case strings.HasSuffix(line, "(ECDSA)"):
+						endIdx = len(parts) - 1
+					}
+					info.comment = strings.Join(parts[2:endIdx], " ")
+				}
+				agentKeys[parts[1]] = info
+			}
+		}
+	}
+
+	// Get identity files from SSH config
+	if serverRepo != nil {
+		servers, _ := serverRepo.ListServers("")
+		for _, server := range servers {
+			for _, identityFile := range server.IdentityFiles {
+				expandedPath := identityFile
+				if strings.HasPrefix(identityFile, "~/") {
+					home, _ := os.UserHomeDir()
+					expandedPath = filepath.Join(home, identityFile[2:])
+				}
+
+				if _, exists := keysMap[expandedPath]; !exists {
+					if key := gs.parseKeyFile(expandedPath, agentKeys); key != nil {
+						key.Source = "config"
+						keysMap[expandedPath] = key
+					}
+				}
+			}
+		}
+	}
+
+	// Also scan ~/.ssh/ directory
+	home, err := os.UserHomeDir()
+	if err == nil {
+		sshDir := filepath.Join(home, ".ssh")
+		if entries, err := os.ReadDir(sshDir); err == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+				name := entry.Name()
+				if strings.HasSuffix(name, ".pub") || name == fileKnownHosts ||
+					name == fileConfig || name == fileAuthorizedKeys {
+					continue
+				}
+
+				fullPath := filepath.Join(sshDir, name)
+				if _, exists := keysMap[fullPath]; !exists {
+					if key := gs.parseKeyFile(fullPath, agentKeys); key != nil {
+						key.Source = "filesystem"
+						keysMap[fullPath] = key
+					}
+				}
+			}
+		}
+	}
+
+	// Convert map to slice
+	keys := make([]domain.SSHKey, 0, len(keysMap))
+	for _, key := range keysMap {
+		keys = append(keys, *key)
+	}
+
+	// Sort by name
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].Name < keys[j].Name
+	})
+
+	return keys, nil
+}
+
+// ListSSHKeysFromAgent returns SSH keys currently loaded in ssh-agent,
+// merged with their file system information to enable comment editing.
+func (gs *gitService) ListSSHKeysFromAgent() ([]domain.SSHKey, error) {
+	keys := make([]domain.SSHKey, 0)
+
+	// Get keys from ssh-agent using -L (uppercase L) to get full public key lines
+	cmd := exec.Command("ssh-add", "-L")
+	output, err := cmd.Output()
+	if err != nil {
+		// ssh-add returns error if agent has no keys
+		return keys, nil
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, line := range lines {
+		key := gs.parseAgentKeyLine(line)
+		if key != nil {
+			keys = append(keys, *key)
+		}
+	}
+
+	// Merge with filesystem keys to populate Path field
+	keys = gs.mergeAgentKeysWithFilesystem(keys)
+
+	return keys, nil
+}
+
+// parseAgentKeyLine parses a single line from ssh-add -L output.
+func (gs *gitService) parseAgentKeyLine(line string) *domain.SSHKey {
+	if line == "" {
+		return nil
+	}
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return nil
+	}
+
+	key := &domain.SSHKey{
+		LoadedInAgent: true,
+		PublicKeyLine: line,
+		Source:        "agent",
+	}
+
+	// Extract key type from first field
+	keyType := strings.TrimPrefix(parts[0], "ssh-")
+	switch keyType {
+	case "rsa":
+		key.Type = keyTypeRSA
+	case "ed25519":
+		key.Type = keyTypeEd25519
+	case "ecdsa":
+		key.Type = keyTypeECDSA
+	case "dsa":
+		key.Type = keyTypeDSA
+	default:
+		// Try to detect from other formats
+		switch {
+		case strings.Contains(line, "RSA"):
+			key.Type = keyTypeRSA
+		case strings.Contains(line, "ED25519"):
+			key.Type = keyTypeEd25519
+		case strings.Contains(line, "ECDSA"):
+			key.Type = keyTypeECDSA
+		}
+	}
+
+	// Extract comment (everything after the key data)
+	if len(parts) >= 3 {
+		key.Comment = strings.Join(parts[2:], " ")
+		key.Name = key.Comment
+	} else {
+		// No comment, use a truncated version of the key data as name
+		if len(parts[1]) > 16 {
+			key.Name = parts[1][:16] + "..."
+		} else {
+			key.Name = parts[1]
+		}
+	}
+
+	// Compute fingerprint from the public key for reliable matching
+	// Use ssh-keygen -lf - to compute fingerprint from stdin
+	var stdout, stderr bytes.Buffer
+	// #nosec G204 -- line is from trusted ssh-add output
+	cmd := exec.Command("ssh-keygen", "-lf", "-")
+	cmd.Stdin = strings.NewReader(line)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		// Parse output: "4096 SHA256:abcdef... comment (RSA)\n"
+		fpFields := strings.Fields(stdout.String())
+		if len(fpFields) >= 2 {
+			key.Fingerprint = fpFields[1]
+			if len(fpFields) >= 1 {
+				if size, err := strconv.Atoi(fpFields[0]); err == nil {
+					key.Size = size
+				}
+			}
+		}
+	}
+
+	return key
+}
+
+// mergeAgentKeysWithFilesystem merges agent keys with filesystem keys to populate Path field.
+func (gs *gitService) mergeAgentKeysWithFilesystem(keys []domain.SSHKey) []domain.SSHKey {
+	fsKeys, err := gs.ListSSHKeysFromConfig(gs.serverRepository)
+	if err != nil {
+		return keys
+	}
+
+	gs.logger.Debugf("mergeAgentKeysWithFilesystem: %d agent keys, %d filesystem keys", len(keys), len(fsKeys))
+
+	// Create maps for different matching strategies
+	fsKeyByPublicKeyLine := make(map[string]domain.SSHKey)
+	fsKeyByFingerprint := make(map[string]domain.SSHKey)
+	fsKeyByName := make(map[string]domain.SSHKey)
+
+	for _, fsKey := range fsKeys {
+		if fsKey.PublicKeyLine != "" {
+			fsKeyByPublicKeyLine[fsKey.PublicKeyLine] = fsKey
+		}
+		if fsKey.Fingerprint != "" {
+			fsKeyByFingerprint[fsKey.Fingerprint] = fsKey
+			gs.logger.Debugf("  FS key fingerprint map: %s -> Path=%s", fsKey.Fingerprint, fsKey.Path)
+		}
+		if fsKey.Name != "" {
+			fsKeyByName[fsKey.Name] = fsKey
+		}
+	}
+
+	// Update agent keys with path from filesystem
+	for i := range keys {
+		gs.logger.Debugf("Processing agent key [%d]: Name=%q, FP=%q, Path=%q",
+			i, keys[i].Name, keys[i].Fingerprint, keys[i].Path)
+		fsKey, matched := gs.matchAgentKeyToFilesystem(&keys[i], fsKeyByPublicKeyLine, fsKeyByFingerprint, fsKeyByName)
+
+		if !matched {
+			gs.logger.Debugf("  -> No match found, Path remains empty")
+			continue
+		}
+
+		// Populate the Path field and copy other attributes
+		keys[i].Path = fsKey.Path
+		// Always update comment from filesystem (it's the source of truth after editing)
+		if fsKey.Comment != "" {
+			keys[i].Comment = fsKey.Comment
+		}
+		if fsKey.Name != "" && len(fsKey.Name) > len(keys[i].Name) {
+			keys[i].Name = fsKey.Name
+		}
+		if keys[i].Fingerprint == "" && fsKey.Fingerprint != "" {
+			keys[i].Fingerprint = fsKey.Fingerprint
+		}
+		if keys[i].Type == "" && fsKey.Type != "" {
+			keys[i].Type = fsKey.Type
+		}
+		if keys[i].Size == 0 && fsKey.Size > 0 {
+			keys[i].Size = fsKey.Size
+		}
+		// Copy HasPublicKey from filesystem key
+		if fsKey.HasPublicKey {
+			keys[i].HasPublicKey = true
+		}
+		// Copy IsEncrypted from filesystem key
+		if fsKey.IsEncrypted {
+			keys[i].IsEncrypted = true
+		}
+	}
+
+	return keys
+}
+
+// matchAgentKeyToFilesystem tries to match an agent key to a filesystem key using multiple strategies.
+func (gs *gitService) matchAgentKeyToFilesystem(
+	key *domain.SSHKey,
+	fsKeyByPublicKeyLine, fsKeyByFingerprint, fsKeyByName map[string]domain.SSHKey,
+) (*domain.SSHKey, bool) {
+	// Strategy 1: Match by public key line (most reliable)
+	if key.PublicKeyLine != "" {
+		if k, ok := fsKeyByPublicKeyLine[key.PublicKeyLine]; ok {
+			gs.logger.Debugf("  -> Matched by public key line to FS key: Path=%s", k.Path)
+			return &k, true
+		}
+	}
+
+	// Strategy 2: Match by fingerprint
+	if key.Fingerprint != "" {
+		gs.logger.Debugf("  -> Trying to match by fingerprint: agent FP=%s", key.Fingerprint)
+		if k, ok := fsKeyByFingerprint[key.Fingerprint]; ok {
+			gs.logger.Debugf("  -> Matched by fingerprint to FS key: Path=%s", k.Path)
+			return &k, true
+		} else {
+			gs.logger.Debugf("  -> No fingerprint match found in filesystem keys")
+		}
+	}
+
+	// Strategy 3: Match by filename (fallback)
+	if key.Name != "" {
+		if k, ok := fsKeyByName[key.Name]; ok {
+			gs.logger.Debugf("  -> Matched by filename to FS key: Path=%s", k.Path)
+			return &k, true
+		}
+	}
+
+	return nil, false
+}
+
+// LoadKeyToAgent loads an SSH key into ssh-agent.
+func (gs *gitService) LoadKeyToAgent(keyPath string) error {
+	cmd := exec.Command("ssh-add", keyPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// UnloadKeyFromAgent removes an SSH key from ssh-agent using its public key line.
+// The publicKeyLine should be the full line from ssh-add -L output (e.g., "ssh-rsa AAAAB3... comment")
+func (gs *gitService) UnloadKeyFromAgent(publicKeyLine string) error {
+	if publicKeyLine == "" {
+		return fmt.Errorf("empty public key line provided")
+	}
+
+	// Capture stderr for better error messages
+	var stderrBuf bytes.Buffer
+	cmd := exec.Command("ssh-add", "-d", "-")
+	cmd.Stdin = strings.NewReader(publicKeyLine + "\n")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Run(); err != nil {
+		stderrMsg := stderrBuf.String()
+		if stderrMsg != "" {
+			return fmt.Errorf("failed to unload key: %w (ssh-add output: %s)", err, stderrMsg)
+		}
+		return fmt.Errorf("failed to unload key: %w", err)
+	}
+
+	gs.logger.Infof("Successfully unloaded key")
+	return nil
+}
+
+// UpdateKeyComment updates the comment for an SSH key using ssh-keygen.
+// Handles file permissions by temporarily making the key writable if needed.
+func (gs *gitService) UpdateKeyComment(keyPath, comment string) error {
+	// Check if private key file exists
+	if _, err := os.Stat(keyPath); err != nil {
+		return fmt.Errorf("key file not found: %w", err)
+	}
+
+	// Check if public key file exists (required for ssh-keygen -c)
+	pubKeyPath := keyPath + ".pub"
+	if _, err := os.Stat(pubKeyPath); err != nil {
+		return fmt.Errorf("public key file (.pub) not found: %w", err)
+	}
+
+	// Get original file permissions for both files
+	originalMode, err := getFileMode(keyPath)
+	if err != nil {
+		return fmt.Errorf("failed to get private key file permissions: %w", err)
+	}
+	pubOriginalMode, err := getFileMode(pubKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to get public key file permissions: %w", err)
+	}
+
+	// Check if files are writable
+	privateReadonly := originalMode&0o200 == 0
+	pubReadonly := pubOriginalMode&0o200 == 0
+
+	// Make private key writable if it's readonly
+	if privateReadonly {
+		if err := os.Chmod(keyPath, 0o600); err != nil {
+			return fmt.Errorf("failed to make private key file writable: %w", err)
+		}
+	}
+
+	// Make public key writable if it's readonly
+	if pubReadonly {
+		if err := os.Chmod(pubKeyPath, 0o600); err != nil {
+			// Restore private key permissions on error
+			if privateReadonly {
+				_ = os.Chmod(keyPath, originalMode)
+			}
+			return fmt.Errorf("failed to make public key file writable: %w", err)
+		}
+	}
+
+	// Use ssh-keygen to update the comment
+	// #nosec G204 -- keyPath and comment are validated inputs
+	cmd := exec.Command("ssh-keygen", "-c", "-C", comment, "-f", keyPath)
+	// Connect stdin/stdout/stderr for interactive passphrase prompt (for encrypted keys)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// Restore original permissions on error
+		if privateReadonly {
+			_ = os.Chmod(keyPath, originalMode)
+		}
+		if pubReadonly {
+			_ = os.Chmod(pubKeyPath, pubOriginalMode)
+		}
+		return fmt.Errorf("failed to update key comment: %w", err)
+	}
+
+	// Restore original permissions if they were readonly
+	if privateReadonly {
+		if err := os.Chmod(keyPath, originalMode); err != nil {
+			gs.logger.Warnw("failed to restore original private key file permissions", "path", keyPath, "error", err)
+			// Don't return error as the comment update succeeded
+		}
+	}
+	if pubReadonly {
+		if err := os.Chmod(pubKeyPath, pubOriginalMode); err != nil {
+			gs.logger.Warnw("failed to restore original public key file permissions", "path", pubKeyPath, "error", err)
+			// Don't return error as the comment update succeeded
+		}
+	}
+
+	gs.logger.Infof("Successfully updated key comment for %s", keyPath)
+	return nil
+}
+
+// getFileMode gets the file mode, using os.Stat if Lstat fails (for symlinks)
+func getFileMode(path string) (os.FileMode, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		// Try Lstat if Stat fails
+		info, err = os.Lstat(path)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return info.Mode(), nil
+}

--- a/internal/core/services/server_service.go
+++ b/internal/core/services/server_service.go
@@ -35,6 +35,7 @@ import (
 
 type serverService struct {
 	serverRepository ports.ServerRepository
+	gitService       ports.GitService
 	logger           *zap.SugaredLogger
 
 	fwMu     sync.Mutex
@@ -42,10 +43,11 @@ type serverService struct {
 }
 
 // NewServerService creates a new instance of serverService.
-func NewServerService(logger *zap.SugaredLogger, sr ports.ServerRepository) ports.ServerService {
+func NewServerService(logger *zap.SugaredLogger, sr ports.ServerRepository, gs ports.GitService) ports.ServerService {
 	return &serverService{
 		logger:           logger,
 		serverRepository: sr,
+		gitService:       gs,
 	}
 }
 


### PR DESCRIPTION
Summary

Implement comprehensive SSH key management (issue #91) with a new 2-panel UI design, ssh-agent integration, and per-repository Git SSH configuration.

New Features

SSH Key Management Panel
- Dedicated SSH Agent panel with load/unload key operations (l/u keys)
- Config Keys panel showing all SSH keys from discovered locations
- Visual indicators: ● (loaded), 🔒 (encrypted), ⚠ (missing .pub)
- SSH key details view with type, size, fingerprint, comment
- Edit SSH key comments (C key)

2-Panel Layout
- Servers panel + SSH Agent panel (Tab/Shift+Tab/mouse to navigate)
- SSH key details shown in server panel when key is configured
- Git repo info displayed when in a Git repository

Git SSH Integration
- Configure Git SSH key per repository (G key)
- Select local or global scope
- Display push remote URL in git info panel
- Clear configuration option

Key Discovery
- SSH keys discovered from config files, not just ~/.ssh/
- Fingerprint-based key operations for reliable identification
- Keychain/ssh-agent status displayed in server list

---

This addresses the common scenario of managing multiple SSH identities (company, personal, vendor accounts) by making it easy to configure which key Git should use for a specific repository. By controlling which SSH key is loaded into ssh-agent we also can control which SSH key will be used for git repository commits/push, in addition to hardcoded fix of the repository.

| Configure Git Repo SSH Key | 
| - | 
| <img width="1804" height="1309" alt="image" src="https://github.com/user-attachments/assets/b59b0c7d-5649-49b8-b24c-43c2fa83ed2f" /> | 
| Show Keychain/ssh-add Keys |
| <img width="1846" height="1196" alt="image" src="https://github.com/user-attachments/assets/76afdadc-747e-45f8-8fb5-de9c874359de" /> |
| Edit SSH Key Comment |
| <img width="1846" height="1196" alt="image" src="https://github.com/user-attachments/assets/c8892d7b-f92f-409a-8ddb-e47864010256" /> |