### PR TITLE
feat(ui): add numeric focus shortcuts for search, servers, details

### DIFF
--- a/internal/adapters/ui/handlers.go
+++ b/internal/adapters/ui/handlers.go
@@ -44,6 +44,15 @@ func (t *tui) handleGlobalKeys(event *tcell.EventKey) *tcell.EventKey {
 	}
 
 	switch event.Rune() {
+	case '0':
+		t.handleSearchFocus()
+		return nil
+	case '1':
+		t.handleServerListFocus()
+		return nil
+	case '2':
+		t.handleDetailsFocus()
+		return nil
 	case 'q':
 		t.handleQuit()
 		return nil
@@ -180,6 +189,18 @@ func (t *tui) handleSearchInput(query string) {
 func (t *tui) handleSearchFocus() {
 	if t.app != nil && t.searchBar != nil {
 		t.app.SetFocus(t.searchBar)
+	}
+}
+
+func (t *tui) handleServerListFocus() {
+	if t.app != nil && t.serverList != nil {
+		t.app.SetFocus(t.serverList)
+	}
+}
+
+func (t *tui) handleDetailsFocus() {
+	if t.app != nil && t.details != nil {
+		t.app.SetFocus(t.details)
 	}
 }
 

--- a/internal/adapters/ui/search_bar.go
+++ b/internal/adapters/ui/search_bar.go
@@ -40,7 +40,7 @@ func (s *SearchBar) build() {
 		SetFieldTextColor(tcell.Color252).
 		SetFieldWidth(30).
 		SetBorder(true).
-		SetTitle(" Search ").
+		SetTitle(" 0 Search ").
 		SetTitleAlign(tview.AlignCenter).
 		SetBorderColor(tcell.Color238).
 		SetTitleColor(tcell.Color250)

--- a/internal/adapters/ui/server_details.go
+++ b/internal/adapters/ui/server_details.go
@@ -39,7 +39,7 @@ func (sd *ServerDetails) build() {
 	sd.TextView.SetDynamicColors(true).
 		SetWrap(true).
 		SetBorder(true).
-		SetTitle(" Details ").
+		SetTitle(" 2 Details ").
 		SetTitleAlign(tview.AlignCenter).
 		SetBorderColor(tcell.Color238).
 		SetTitleColor(tcell.Color250)

--- a/internal/adapters/ui/server_list.go
+++ b/internal/adapters/ui/server_list.go
@@ -39,7 +39,7 @@ func NewServerList() *ServerList {
 func (sl *ServerList) build() {
 	sl.List.ShowSecondaryText(false)
 	sl.List.SetBorder(true).
-		SetTitle(" Servers ").
+		SetTitle(" 1 Servers ").
 		SetTitleAlign(tview.AlignCenter).
 		SetBorderColor(tcell.Color238).
 		SetTitleColor(tcell.Color250)

--- a/internal/adapters/ui/tui.go
+++ b/internal/adapters/ui/tui.go
@@ -142,6 +142,6 @@ func (t *tui) loadInitialData() *tui {
 
 func (t *tui) updateListTitle() {
 	if t.serverList != nil {
-		t.serverList.SetTitle(" Servers — Sort: " + t.sortMode.String() + " ")
+		t.serverList.SetTitle(" 1 Servers — Sort: " + t.sortMode.String() + " ")
 	}
 }


### PR DESCRIPTION
Add numeric labels to the Search, Servers, and Details panels and introduce 0/1/2
keyboard shortcuts to move focus between them. This makes the primary UI sections easier
to identify and jump to quickly without changing existing navigation behavior.

  Changes

  - UI: label panel titles with 0 (Search), 1 (Servers), and 2 (Details) for quick visual
    mapping
  - UI: handle 0/1/2 as global keys to focus Search, Server List, and Details respectively
  - UI: update the dynamic server list title to retain the 1 prefix alongside sort mode