### PR TITLE
feat(cli): support direct SSH connection via server alias argument

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,6 +64,35 @@ func main() {
 	}
 	rootCmd.SilenceUsage = true
 
+	// Add --server flag to connect directly to a server
+	rootCmd.Flags().StringP("server", "s", "", "Connect directly to the specified server alias")
+
+	// Handle direct SSH connection when server flag is provided
+	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		serverAlias, _ := cmd.Flags().GetString("server")
+
+		// If server alias provided as flag or argument, connect directly
+		if serverAlias == "" && len(args) > 0 {
+			serverAlias = args[0]
+		}
+
+		if serverAlias != "" {
+			server, err := serverService.GetServerByAlias(serverAlias)
+			if err != nil {
+				log.Errorw("failed to get server", "error", err, "alias", serverAlias)
+				return fmt.Errorf("failed to connect to server '%s': %w", serverAlias, err)
+			}
+			if server == nil {
+				log.Errorw("server not found", "alias", serverAlias)
+				return fmt.Errorf("server '%s' not found in SSH config", serverAlias)
+			}
+			return serverService.SSH(server.Alias)
+		}
+
+		// Otherwise, run the TUI
+		return tui.Run()
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/internal/adapters/data/ssh_config_file/ssh_config_file_repo.go
+++ b/internal/adapters/data/ssh_config_file/ssh_config_file_repo.go
@@ -73,6 +73,30 @@ func (r *Repository) ListServers(query string) ([]domain.Server, error) {
 	return r.filterServers(servers, query), nil
 }
 
+// GetServerByAlias returns a server by its alias, or nil if not found.
+func (r *Repository) GetServerByAlias(alias string) (*domain.Server, error) {
+	cfg, err := r.loadConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	servers := r.toDomainServer(cfg)
+	metadata, err := r.metadataManager.loadAll()
+	if err != nil {
+		r.logger.Warnf("Failed to load metadata: %v", err)
+		metadata = make(map[string]ServerMetadata)
+	}
+	servers = r.mergeMetadata(servers, metadata)
+
+	for i := range servers {
+		if servers[i].Alias == alias {
+			return &servers[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
 // AddServer adds a new server to the SSH config.
 func (r *Repository) AddServer(server domain.Server) error {
 	cfg, err := r.loadConfig()

--- a/internal/core/ports/repositories.go
+++ b/internal/core/ports/repositories.go
@@ -18,6 +18,7 @@ import "github.com/Adembc/lazyssh/internal/core/domain"
 
 type ServerRepository interface {
 	ListServers(query string) ([]domain.Server, error)
+	GetServerByAlias(alias string) (*domain.Server, error)
 	UpdateServer(server domain.Server, newServer domain.Server) error
 	AddServer(server domain.Server) error
 	DeleteServer(server domain.Server) error

--- a/internal/core/ports/services.go
+++ b/internal/core/ports/services.go
@@ -22,6 +22,7 @@ import (
 
 type ServerService interface {
 	ListServers(query string) ([]domain.Server, error)
+	GetServerByAlias(alias string) (*domain.Server, error)
 	UpdateServer(server domain.Server, newServer domain.Server) error
 	AddServer(server domain.Server) error
 	DeleteServer(server domain.Server) error

--- a/internal/core/services/server_service.go
+++ b/internal/core/services/server_service.go
@@ -73,6 +73,11 @@ func (s *serverService) ListServers(query string) ([]domain.Server, error) {
 	return servers, nil
 }
 
+// GetServerByAlias returns a server by its alias, or nil if not found.
+func (s *serverService) GetServerByAlias(alias string) (*domain.Server, error) {
+	return s.serverRepository.GetServerByAlias(alias)
+}
+
 // validateServer performs core validation of server fields.
 func validateServer(srv domain.Server) error {
 	if strings.TrimSpace(srv.Alias) == "" {


### PR DESCRIPTION
Allow connecting directly to a server without launching the TUI by passing the server alias as a positional argument or via --server/-s flag.

Usage:
>     lazyssh host
>     lazyssh --server host
>     lazyssh -s host

Adds GetServerByAlias to repository and service layers to look up a server by alias from the SSH config. Returns a clear error if the server is not found