### PR TITLE
improve(config): Use XDG Base Directory for config and log paths when environment variables are available

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,7 +49,16 @@ func main() {
 		os.Exit(1)
 	}
 	sshConfigFile := filepath.Join(home, ".ssh", "config")
+
 	metaDataFile := filepath.Join(home, ".lazyssh", "metadata.json")
+	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
+		configDir := filepath.Join(xdgConfig, "lazyssh")
+		if err := os.MkdirAll(configDir, 0o750); err != nil {
+			log.Errorw("failed to create XDG config directory", "error", err)
+			os.Exit(1)
+		}
+		metaDataFile = filepath.Join(configDir, "metadata.json")
+	}
 
 	serverRepo := ssh_config_file.NewRepository(log, sshConfigFile, metaDataFile)
 	serverService := services.NewServerService(log, serverRepo)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -35,11 +35,18 @@ func New(service string, outputPaths ...string) (*zap.SugaredLogger, error) {
 		"service": service,
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var logDir string
+
+	if stateDir := os.Getenv("XDG_STATE_HOME"); stateDir != "" {
+		logDir = filepath.Join(stateDir, "lazyssh")
+	} else {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		logDir = filepath.Join(home, ".lazyssh")
 	}
-	logDir := filepath.Join(home, ".lazyssh")
+
 	if err := os.MkdirAll(logDir, 0o750); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use XDG Base Directory specifications when the `$XDG_CONFIG_HOME` and `$XDG_STATE_HOME` environment variables are available.
