### PR TITLE
fix: 't' key tag editing on fresh entries and allow last-tag removal

### DIFF
--- a/internal/adapters/ui/handlers.go
+++ b/internal/adapters/ui/handlers.go
@@ -408,7 +408,14 @@ func (t *tui) showEditTagsForm(server domain.Server) {
 
 		newServer := server
 		newServer.Tags = tags
-		_ = t.serverService.UpdateServer(server, newServer)
+		if err := t.serverService.UpdateServer(server, newServer); err != nil {
+			modal := tview.NewModal().
+				SetText(fmt.Sprintf("Save failed: %v", err)).
+				AddButtons([]string{"Close"}).
+				SetDoneFunc(func(buttonIndex int, buttonLabel string) { t.handleModalClose() })
+			t.app.SetRoot(modal, true)
+			return
+		}
 		// Refresh UI and go back
 		t.refreshServerList()
 		t.returnToMain()

--- a/internal/adapters/ui/server_list.go
+++ b/internal/adapters/ui/server_list.go
@@ -68,6 +68,11 @@ func (sl *ServerList) build() {
 }
 
 func (sl *ServerList) UpdateServers(servers []domain.Server) {
+	currentAlias := ""
+	if idx := sl.List.GetCurrentItem(); idx >= 0 && idx < len(sl.servers) {
+		currentAlias = sl.servers[idx].Alias
+	}
+
 	sl.servers = servers
 	sl.List.Clear()
 
@@ -81,10 +86,20 @@ func (sl *ServerList) UpdateServers(servers []domain.Server) {
 		})
 	}
 
+	restoreIdx := 0
+	if currentAlias != "" {
+		for i, s := range servers {
+			if s.Alias == currentAlias {
+				restoreIdx = i
+				break
+			}
+		}
+	}
+
 	if sl.List.GetItemCount() > 0 {
-		sl.List.SetCurrentItem(0)
+		sl.List.SetCurrentItem(restoreIdx)
 		if sl.onSelectionChange != nil {
-			sl.onSelectionChange(sl.servers[0])
+			sl.onSelectionChange(sl.servers[restoreIdx])
 		}
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes two bugs related to the `t` key tag editing feature:

### Bug 1: `t` key silently fails on fresh entries (never edited via `e`)

**Root cause**: In `handlers.go:411`, the `showEditTagsForm` save callback discards the error from `UpdateServer` with `_ = t.serverService.UpdateServer(...)`. If the SSH config write fails (e.g., permissions issue), the tags are never saved but the UI shows "Tags updated" as if it succeeded.

**Fix**: The error is now properly surfaced via an error modal, matching the behavior of `handleServerSave` (used by the `e` key).

### Bug 2: Selection jumps to first entry after tag save

**Root cause**: In `server_list.go:85`, `UpdateServers` always resets the selected item to index 0 after refreshing the list, making it appear that tags were not saved on the edited server.

**Fix**: `UpdateServers` now tracks the currently selected server alias before refresh and restores the selection to that same server afterward.

### Notes
- The nil-guard fix in `metadata_manager.go` (for clearing the last tag) was already present in the codebase — no changes needed there.
- All existing tests pass.

Closes #(issue if applicable)